### PR TITLE
fix(immich): use hyphen in db/redis hostnames

### DIFF
--- a/ansible/docker-compose/immich-stack.yml
+++ b/ansible/docker-compose/immich-stack.yml
@@ -7,11 +7,11 @@ services:
       - /data/immich/upload:/data
       - /etc/localtime:/etc/localtime:ro
     environment:
-      - DB_HOSTNAME=immich_postgres
+      - DB_HOSTNAME=immich-postgres
       - DB_USERNAME=immich
       - DB_PASSWORD=${IMMICH_DB_PASSWORD}
       - DB_DATABASE_NAME=immich
-      - REDIS_HOSTNAME=immich_redis
+      - REDIS_HOSTNAME=immich-redis
       - TZ=Europe/Amsterdam
       - IMMICH_TELEMETRY_INCLUDE=all
     ports:


### PR DESCRIPTION
## Motivation

Redeploying immich to pick up the new telemetry env var
and postgres-exporter sidecar broke immich-server with:

\`\`\`
Error: getaddrinfo ENOTFOUND immich_postgres
\`\`\`

Root cause: \`DB_HOSTNAME=immich_postgres\` and
\`REDIS_HOSTNAME=immich_redis\` in the existing compose file
use underscores, but the service definitions declare
\`container_name: immich-postgres\` and
\`immich-redis\` with hyphens. The old running containers
were created before \`container_name\` was added to the
file and therefore had underscore-derived default names,
so the lookup happened to work. As soon as a recreate
forced them to hyphen names the DNS lookup broke.

## Implementation information

Swap both hostnames to hyphens to match the declared
container names. Running state on the jellyfin LXC already
fixed manually to stop the crashloop — immich-server is
healthy, postgres-exporter and native telemetry both
reachable from homelab on 9187 / 8081.

Alternatives considered:

- Use the service name (\`database\`, \`redis\`) as hostname
  instead. Works too but would have required dropping the
  existing volume-name alignment with container_name.

## Supporting documentation

> Changelog: fix(immich): use hyphen in db/redis hostnames