### PR TITLE
feat(monitoring): add valkey/redis exporters

### DIFF
--- a/ansible/docker-compose/immich-stack.yml
+++ b/ansible/docker-compose/immich-stack.yml
@@ -51,6 +51,17 @@ services:
       test: redis-cli ping || exit 1
     restart: unless-stopped
 
+  immich-redis-exporter:
+    container_name: immich-redis-exporter
+    image: oliver006/redis_exporter:v1.82.0
+    restart: unless-stopped
+    environment:
+      REDIS_ADDR: "redis://immich-redis:6379"
+    ports:
+      - "9121:9121"
+    depends_on:
+      - redis
+
   database:
     container_name: immich-postgres
     image: >-

--- a/ansible/docker-compose/nextcloud-stack.yml
+++ b/ansible/docker-compose/nextcloud-stack.yml
@@ -25,6 +25,18 @@ services:
     healthcheck:
       test: redis-cli ping || exit 1
 
+  nextcloud-redis-exporter:
+    container_name: nextcloud-redis-exporter
+    image: oliver006/redis_exporter:v1.82.0
+    restart: unless-stopped
+    environment:
+      REDIS_ADDR: "redis://nextcloud-redis:6379"
+    ports:
+      - "9121:9121"
+    depends_on:
+      nextcloud-redis:
+        condition: service_healthy
+
   nextcloud-postgres-exporter:
     container_name: nextcloud-postgres-exporter
     image: quay.io/prometheuscommunity/postgres-exporter:v0.19.1

--- a/ansible/docker-compose/paperless-stack.yml
+++ b/ansible/docker-compose/paperless-stack.yml
@@ -28,6 +28,18 @@ services:
       timeout: 5s
       retries: 5
 
+  paperless-redis-exporter:
+    container_name: paperless-redis-exporter
+    image: oliver006/redis_exporter:v1.82.0
+    restart: unless-stopped
+    environment:
+      REDIS_ADDR: "redis://paperless-redis:6379"
+    ports:
+      - "9122:9121"  # 9121 taken by nextcloud-redis-exporter on same host
+    depends_on:
+      paperless-broker:
+        condition: service_healthy
+
   paperless-postgres-exporter:
     container_name: paperless-postgres-exporter
     image: quay.io/prometheuscommunity/postgres-exporter:v0.19.1


### PR DESCRIPTION
## Motivation

Three of our stacks run a valkey/redis for caching or
queueing: immich (caching + ml job queue), nextcloud
(session cache), paperless (celery broker). cAdvisor
container stats do not tell us hit ratio, evictions,
blocked clients, or slow commands.

## Implementation information

Add \`oliver006/redis_exporter:v1.82.0\` sidecar to each
stack:

| Stack | Host | Port |
|---|---|---|
| immich | jellyfin LXC | 9121 |
| nextcloud | custom-workloads | 9121 |
| paperless | custom-workloads | **9122** (9121 taken) |

Exporter connects over the default compose network to
each stack's valkey container. No auth — valkey instances
are all localhost-only behind the compose network.

Follow-up smart-home PR will add \`home-nas-valkey\` scrape
job once the stacks are redeployed.

## Supporting documentation

> Changelog: feat(monitoring): add valkey/redis exporters