### PR TITLE
feat(monitoring): add qbit + exportarr sidecars

### DIFF
--- a/ansible/docker-compose/downloads-stack.yml
+++ b/ansible/docker-compose/downloads-stack.yml
@@ -43,3 +43,17 @@ services:
       - /mnt/tank-media/downloads:/data/downloads
     stop_grace_period: 120s
     restart: unless-stopped
+
+  qbittorrent-exporter:
+    image: ghcr.io/esanchezm/prometheus-qbittorrent-exporter:1.6.0
+    container_name: qbittorrent-exporter
+    network_mode: host
+    environment:
+      QBITTORRENT_HOST: localhost
+      QBITTORRENT_PORT: "8080"
+      # LocalHostAuth=false in qBittorrent.conf — localhost scraping is
+      # unauthenticated, so no credentials needed.
+      EXPORTER_PORT: "9102"
+    restart: unless-stopped
+    depends_on:
+      - qbittorrent

--- a/ansible/docker-compose/media-management-stack.yml
+++ b/ansible/docker-compose/media-management-stack.yml
@@ -143,3 +143,75 @@ services:
     ports:
       - 9876:9876
     restart: unless-stopped
+
+  # --- Prometheus exporters ---
+
+  exportarr-sonarr:
+    image: ghcr.io/onedr0p/exportarr:v2.3.0
+    container_name: exportarr-sonarr
+    command: ["sonarr"]
+    environment:
+      PORT: "9707"
+      URL: "http://sonarr:8989"
+      APIKEY: ${SONARR_API_KEY}
+    ports:
+      - 9707:9707
+    restart: unless-stopped
+    depends_on:
+      - sonarr
+
+  exportarr-radarr:
+    image: ghcr.io/onedr0p/exportarr:v2.3.0
+    container_name: exportarr-radarr
+    command: ["radarr"]
+    environment:
+      PORT: "9708"
+      URL: "http://radarr:7878"
+      APIKEY: ${RADARR_API_KEY}
+    ports:
+      - 9708:9708
+    restart: unless-stopped
+    depends_on:
+      - radarr
+
+  exportarr-lidarr:
+    image: ghcr.io/onedr0p/exportarr:v2.3.0
+    container_name: exportarr-lidarr
+    command: ["lidarr"]
+    environment:
+      PORT: "9709"
+      URL: "http://lidarr:8686"
+      APIKEY: ${LIDARR_API_KEY}
+    ports:
+      - 9709:9709
+    restart: unless-stopped
+    depends_on:
+      - lidarr
+
+  exportarr-prowlarr:
+    image: ghcr.io/onedr0p/exportarr:v2.3.0
+    container_name: exportarr-prowlarr
+    command: ["prowlarr"]
+    environment:
+      PORT: "9710"
+      URL: "http://prowlarr:9696"
+      APIKEY: ${PROWLARR_API_KEY}
+    ports:
+      - 9710:9710
+    restart: unless-stopped
+    depends_on:
+      - prowlarr
+
+  exportarr-bazarr:
+    image: ghcr.io/onedr0p/exportarr:v2.3.0
+    container_name: exportarr-bazarr
+    command: ["bazarr"]
+    environment:
+      PORT: "9711"
+      URL: "http://bazarr:6767"
+      APIKEY: ${BAZARR_API_KEY}
+    ports:
+      - 9711:9711
+    restart: unless-stopped
+    depends_on:
+      - bazarr

--- a/ansible/playbooks/deploy-media-management.yml
+++ b/ansible/playbooks/deploy-media-management.yml
@@ -1,0 +1,70 @@
+---
+- name: Deploy media-management (*arr) stack to media-management LXC
+  hosts: media-management
+  become: true
+
+  vars:
+    compose_dir: /opt/media-management-stack
+    compose_file: /opt/media-management-stack/docker-compose.yml
+    env_file: /opt/media-management-stack/.env
+
+  tasks:
+    - name: Ensure Docker service is running
+      ansible.builtin.systemd:
+        name: docker
+        state: started
+        enabled: true
+
+    - name: Create compose directory
+      ansible.builtin.file:
+        path: "{{ compose_dir }}"
+        state: directory
+        mode: '0755'
+
+    - name: Copy docker-compose file
+      ansible.builtin.copy:
+        src: ../docker-compose/media-management-stack.yml
+        dest: "{{ compose_file }}"
+        mode: '0644'
+
+    - name: Extract arr API keys from sops
+      ansible.builtin.shell: |
+        set -o pipefail
+        sops -d --extract '["{{ item }}"]' {{ playbook_dir }}/../secrets/secrets.yaml
+      register: arr_key_results
+      delegate_to: localhost
+      become: false
+      no_log: true
+      changed_when: false
+      loop:
+        - sonarr_api_key
+        - radarr_api_key
+        - lidarr_api_key
+        - prowlarr_api_key
+        - bazarr_api_key
+
+    - name: Set arr API key facts
+      ansible.builtin.set_fact:
+        arr_keys: >-
+          {{ dict(arr_key_results.results
+                  | map(attribute='item')
+                  | zip(arr_key_results.results | map(attribute='stdout'))) }}
+      no_log: true
+
+    - name: Create .env file
+      ansible.builtin.copy:
+        content: |
+          SONARR_API_KEY={{ arr_keys.sonarr_api_key }}
+          RADARR_API_KEY={{ arr_keys.radarr_api_key }}
+          LIDARR_API_KEY={{ arr_keys.lidarr_api_key }}
+          PROWLARR_API_KEY={{ arr_keys.prowlarr_api_key }}
+          BAZARR_API_KEY={{ arr_keys.bazarr_api_key }}
+        dest: "{{ env_file }}"
+        mode: '0600'
+      no_log: true
+
+    - name: Deploy media-management stack
+      community.docker.docker_compose_v2:
+        project_src: "{{ compose_dir }}"
+        state: present
+        pull: missing

--- a/ansible/secrets/secrets.yaml
+++ b/ansible/secrets/secrets.yaml
@@ -11,6 +11,11 @@ mixarr_session_secret: ENC[AES256_GCM,data:bNkh9+fj3ouyluRYL6t8nEDs0qrck07cHgxVK
 proxmox_password: ENC[AES256_GCM,data:eeEnllTbYvo2A7Vz,iv:y8ZID1tkaU1uSlAkLwtbUTan61zkNIHZ72LKBFPw0tM=,tag:RaE+Mff8J2gLfeUHDsrM3A==,type:str]
 finance_db_password: ENC[AES256_GCM,data:rKdhe8+RAATIZ0oVMFauLetQrNLDR3Xt6YcLDWYs8ec=,iv:MdHJeBRuamFsnBVrRZvtyqKWL4IFIe67Lr7Ixit0L2I=,tag:RMF6f+SfE97ORF0zQQqUfw==,type:str]
 finance_app_password: ENC[AES256_GCM,data:VFM1eSS4Lk1ceDGuSBGI6n1V5mtNWd/ENZVmPL3snlg=,iv:nestS1bqAgM2rtogmNWNcTTEWqY2Hdjl8Iz2PLaJkcw=,tag:J3E3fngchqAxtfPdVceGFw==,type:str]
+sonarr_api_key: ENC[AES256_GCM,data:UP2GRsfhQI4tnIKmuVs68tncy7A+CRWftqKNiqImo6U=,iv:MhdrAxXbAbuQkfS9gO5vrDorhXIqNjvaniD71DNMMR0=,tag:w1NYgYZGC2VyZiAwGhmuWw==,type:str]
+radarr_api_key: ENC[AES256_GCM,data:2Mudx+llSg5B6FX80qFCvYALlyhXIdtb/JpgZitSPG0=,iv:0beF/QCpO/ikVQN3EHYrnRn/xUpDPcAhHwwJekBl6A4=,tag:dKd5eNnLp+V+1jlmNVnywg==,type:str]
+lidarr_api_key: ENC[AES256_GCM,data:e5wWgsYgI2ATKkVOtxLdXb4ntWJZR3IHlyDocNo7rRo=,iv:pl3jrusHMJPyEKUXLZ69TwRvRqc1F1PJUyFve79pejQ=,tag:6n4kNssQJmj3v9vWAYH60Q==,type:str]
+prowlarr_api_key: ENC[AES256_GCM,data:iDnZ04xxDUFm/omGM+HvkjsHpEltkzyt/hTt2O+ZJe0=,iv:Knt9nxYKGzGyUiZKzBeAPTwbRalf+dGVfu4khKBvlco=,tag:lQeHigw5S/S1VZNIb/IJzw==,type:str]
+bazarr_api_key: ENC[AES256_GCM,data:673LYSaYYsmmIwmXbaVtWQbV/uTTBt+7JbSFbiO8yMA=,iv:gbhV5/gym/5SJBmpczqNYNY+8wx6rWD7syaXVPzclx8=,tag:Nr+YqbfH42CcO/hACimSxw==,type:str]
 sops:
     age:
         - recipient: age1kfklkd3xuacvfu0gy35v7cwk5lw8y9xv0lr5hs2ddyn82ww9mdlslfth6h
@@ -22,7 +27,7 @@ sops:
             S1JBdG4xTWpHZXIwalBYMjhHdG1IUTQK+IlzvzJWhK3ZHi/48jZInG4nNveLvGeC
             YOePg6TNURkYfpx2hT7rjbSyzCH27l7I3ylSd6F4I8PG/utFFMnwYQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-07T15:39:53Z"
-    mac: ENC[AES256_GCM,data:tBRzEjVEWx2/gHa5vfGIeimW3l+0/rfnVRQb76LbuexrDDlhCBlajJZySBWc24BOgHev8b9LJI5EIdgsL2CHgZPhbOhdY9fW3maQ9Gh2OfVIoYJ4S31PfcjYIXA2WXH0FzX9vM/TVx0LEkRQ9aY+NX+zeGWVJ+ykzUZuOMIuMB0=,iv:SI8DJDxs1PTfL+uVQLRRVtyD0S4b+f0Yw1wbney8o04=,tag:4VqmsUy2q9Hcu10xePBnsw==,type:str]
+    lastmodified: "2026-04-09T15:24:49Z"
+    mac: ENC[AES256_GCM,data:qfxmOxiCMWj6EXwEWjjZiv058/snmD3s73p5eOezsthClx42KBGWyNX3ldu2+9pK5zqVtlW9q81IzIBIqVwKPYxjWCd6ylEAMXXgBwXLmBCxEDDwOFbzWYn5yvo9T/qYZE6TXHW0vHATIDxgf2PzQLMMdLRx9J8r4zp7JyvSCBE=,iv:619te75qA01de8rQ6Gq7+NPCunrspW33ZClR+wtQtS8=,tag:5QupaGtijwWkpueRyo+n8A==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0


### PR DESCRIPTION
## Motivation

Two batches of app exporters for the media stack on
downloads LXC and media-management LXC. Neither service
group has any metrics today beyond cadvisor container
stats.

## Implementation information

### downloads stack — qbittorrent-exporter

\`esanchezm/prometheus-qbittorrent-exporter:1.6.0\` with
\`network_mode: host\` to match qbit itself. LocalHostAuth
is off in qBittorrent.conf so no credentials needed.
Exposes \`:9102\` (9100 and 9101 owned by node_exporter
and cAdvisor).

### media-management stack — exportarr

\`ghcr.io/onedr0p/exportarr:v2.3.0\` x5 for sonarr, radarr,
lidarr, prowlarr, bazarr on ports 9707-9711.

API keys extracted from each service's running config and
stored in sops (\`ansible/secrets/secrets.yaml\`) as
\`sonarr_api_key\`, \`radarr_api_key\`, etc.

New playbook \`deploy-media-management.yml\`: the stack
had no dedicated deploy playbook because the original
bootstrap was a one-off \`migrate-vm-to-lxc.yml\`. The new
playbook mirrors the finance-buddy / nextcloud pattern —
copies the compose file, extracts keys from sops,
templates an \`.env\`, and runs docker compose.

Follow-up smart-home PR will add scrape jobs for all six
new targets (1 qbit + 5 exportarr).

## Supporting documentation

> Changelog: feat(monitoring): add qbit + exportarr sidecars