### PR TITLE
fix(media): broken image tags

### DIFF
--- a/ansible/docker-compose/downloads-stack.yml
+++ b/ansible/docker-compose/downloads-stack.yml
@@ -45,7 +45,9 @@ services:
     restart: unless-stopped
 
   qbittorrent-exporter:
-    image: ghcr.io/esanchezm/prometheus-qbittorrent-exporter:1.6.0
+    # Upstream publishes only `latest` and sha-based tags on Docker Hub;
+    # no semver tags despite the GitHub release naming scheme.
+    image: esanchezm/prometheus-qbittorrent-exporter:latest
     container_name: qbittorrent-exporter
     network_mode: host
     environment:

--- a/ansible/docker-compose/media-management-stack.yml
+++ b/ansible/docker-compose/media-management-stack.yml
@@ -129,7 +129,7 @@ services:
     restart: unless-stopped
 
   lingarr:
-    image: ghcr.io/lingarr-translate/lingarr:v1.4.0
+    image: ghcr.io/lingarr-translate/lingarr:v1.0.9
     container_name: lingarr
     environment:
       - PUID=1000


### PR DESCRIPTION
## Motivation

Two unrelated image tag bugs surfaced while deploying the
Phase 4 exporters:

1. \`esanchezm/prometheus-qbittorrent-exporter\` — pinned
   to \`:1.6.0\` in #94 but Docker Hub never published a
   semver tag matching that release.
2. \`ghcr.io/lingarr-translate/lingarr:v1.4.0\` — never
   existed upstream. Latest release is 1.0.9. The bogus
   pin blocked every redeploy of the media-management
   stack; the running container had been pulled as
   \`:latest\` before the pin landed.

## Implementation information

- qbit exporter → \`esanchezm/prometheus-qbittorrent-exporter:latest\`
  with an inline comment explaining the tag choice.
- lingarr → \`ghcr.io/lingarr-translate/lingarr:v1.0.9\` which
  matches the upstream Latest release.

Both hosts already manually synced — qbit-exporter
reachable at 192.168.40.162:9102/metrics (http=200) and
media-management deploy will succeed on the next run.

## Supporting documentation

> Changelog: fix(media): broken image tags