### PR TITLE
fix(media): drop v-prefix from lingarr tag

### DIFF
--- a/ansible/docker-compose/media-management-stack.yml
+++ b/ansible/docker-compose/media-management-stack.yml
@@ -129,7 +129,7 @@ services:
     restart: unless-stopped
 
   lingarr:
-    image: ghcr.io/lingarr-translate/lingarr:v1.0.9
+    image: ghcr.io/lingarr-translate/lingarr:1.0.9
     container_name: lingarr
     environment:
       - PUID=1000


### PR DESCRIPTION
## Motivation

Follow-up to #95. v1.0.9 still manifest-unknown because
ghcr.io tags use plain semver without the v prefix.
GitHub releases list them as 1.0.9 too actually — I
added the v when translating to image tag out of habit.

Confirmed both variants by pulling locally:
- \`ghcr.io/lingarr-translate/lingarr:v1.0.9\` → manifest unknown
- \`ghcr.io/lingarr-translate/lingarr:1.0.9\` → ok

## Implementation information

One character change.

## Supporting documentation

> Changelog: fix(media): drop v-prefix from lingarr tag