### PR TITLE
fix(bazarr): keep general.debug off after deploy

### DIFF
--- a/ansible/playbooks/deploy-media-management.yml
+++ b/ansible/playbooks/deploy-media-management.yml
@@ -68,3 +68,27 @@
         project_src: "{{ compose_dir }}"
         state: present
         pull: missing
+
+    - name: Check bazarr config file exists
+      ansible.builtin.stat:
+        path: /data/bazarr/config/config/config.yaml
+      register: bazarr_config_stat
+
+    # Bazarr ships with general.debug=true which generates ~185k log lines per
+    # 5min from subliminal_patch + urllib3. Force it off so promtail does not
+    # drown homelab Loki. Anchored on the unique days_to_upgrade_subs key
+    # right above to avoid touching the subsync.debug entry further down.
+    - name: Disable bazarr general.debug
+      ansible.builtin.replace:
+        path: /data/bazarr/config/config/config.yaml
+        regexp: '^(  days_to_upgrade_subs:.*\n  )debug: true$'
+        replace: '\1debug: false'
+      when: bazarr_config_stat.stat.exists
+      notify: Restart bazarr
+
+  handlers:
+    - name: Restart bazarr
+      community.docker.docker_container:
+        name: bazarr
+        state: started
+        restart: true


### PR DESCRIPTION
## Motivation

Caught in Phase 5 promtail rollout: bazarr was generating
~185k log lines per 5 minutes from \`subliminal_patch\` and
\`urllib3\` spam, dominating Loki ingest. Manually flipped
\`general.debug\` to false on the host but the change was
not in git — would re-emerge on a clean rebuild because
bazarr ships with that key set to true.

## Implementation information

Idempotent post-deploy task in
\`deploy-media-management.yml\`:

1. Stat \`/data/bazarr/config/config/config.yaml\` (skip
   the patch on a fresh install where bazarr has not
   created the file yet — it will be regenerated with
   the default once bazarr boots).
2. \`replace\` task with a multiline regex anchored on the
   unique \`days_to_upgrade_subs\` key right above the
   target line. This avoids touching the unrelated
   \`subsync.debug\` entry further down which is also
   \`debug: true\` at indent 2 but in a different section.
3. Notify a handler that restarts the bazarr container
   only if the file actually changed.

Alternatives considered:

- Bazarr env var: there isn't one — bazarr controls
  logging entirely through its UI-managed config.yaml.
- Pre-seed full config.yaml from a template: too invasive
  for a single-key fix and would fight with bazarr's own
  writes.
- Document in CLAUDE.md: not enforced.

## Supporting documentation

> Changelog: fix(bazarr): keep general.debug off after deploy