### PR TITLE
fix(actions): split manual deploy into own file

### DIFF
--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -1,0 +1,73 @@
+name: Deploy (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      stack:
+        description: Stack to deploy
+        type: choice
+        required: true
+        options:
+          - infrastructure
+          - media-management
+          - jellyfin
+          - immich
+          - nextcloud
+          - paperless
+          - synapse
+          - finance-buddy
+          - downloads
+          - monitoring-agents
+
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, home-nas]
+    steps:
+      # Cannot pin by digest: Renovate will manage action updates
+      - uses: actions/checkout@v6
+
+      # Cannot pin by digest: Renovate will manage action updates
+      - uses: actions/cache@v5
+        with:
+          path: ~/.ansible/collections
+          key: ${{ runner.os }}-ansible-collections-${{ hashFiles('ansible/requirements.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-ansible-collections-
+
+      - name: Install Ansible collections
+        run: ansible-galaxy collection install -r ansible/requirements.yml
+
+      - name: Resolve playbook + limit
+        id: map
+        run: |
+          case "${{ inputs.stack }}" in
+            infrastructure)     pb=deploy-infrastructure-stack.yml; lim=infrastructure ;;
+            media-management)   pb=deploy-media-management.yml;     lim=media-management ;;
+            jellyfin)           pb=deploy-media-stack.yml;          lim=jellyfin ;;
+            immich)             pb=deploy-immich.yml;               lim=jellyfin ;;
+            nextcloud)          pb=deploy-nextcloud.yml;            lim=custom-workloads ;;
+            paperless)          pb=deploy-paperless.yml;            lim=custom-workloads ;;
+            synapse)            pb=deploy-synapse.yml;              lim=synapse ;;
+            finance-buddy)      pb=deploy-finance-buddy.yml;        lim=pet-projects ;;
+            downloads)          pb=deploy-downloads.yml;            lim=downloads ;;
+            monitoring-agents)  pb=deploy-monitoring-agents.yml;    lim=all ;;
+            *) echo "Unknown stack: ${{ inputs.stack }}"; exit 1 ;;
+          esac
+          {
+            echo "playbook=$pb"
+            echo "limit=$lim"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run playbook
+        working-directory: ansible
+        env:
+          ANSIBLE_HOST_KEY_CHECKING: "False"
+        run: ansible-playbook -i inventory.yml playbooks/${{ steps.map.outputs.playbook }} --limit ${{ steps.map.outputs.limit }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,23 +3,6 @@ name: Deploy
 on:
   push:
     branches: [main]
-  workflow_dispatch:
-    inputs:
-      stack:
-        description: Stack to deploy
-        type: choice
-        required: true
-        options:
-          - infrastructure
-          - media-management
-          - jellyfin
-          - immich
-          - nextcloud
-          - paperless
-          - synapse
-          - finance-buddy
-          - downloads
-          - monitoring-agents
 
 concurrency:
   group: deploy
@@ -35,7 +18,6 @@ jobs:
 
   changes:
     needs: validate
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       stacks: ${{ steps.filter.outputs.changes }}
@@ -80,17 +62,14 @@ jobs:
               - 'ansible/playbooks/deploy-monitoring-agents.yml'
 
   deploy:
-    needs: [validate, changes]
-    if: |
-      always() && needs.validate.result == 'success' &&
-      ((github.event_name == 'push' && needs.changes.result == 'success' && needs.changes.outputs.stacks != '[]')
-       || github.event_name == 'workflow_dispatch')
+    needs: changes
+    if: needs.changes.outputs.stacks != '[]'
     runs-on: [self-hosted, home-nas]
     strategy:
       fail-fast: false
       max-parallel: 1
       matrix:
-        stack: ${{ github.event_name == 'workflow_dispatch' && fromJson(format('["{0}"]', github.event.inputs.stack)) || fromJson(needs.changes.outputs.stacks) }}
+        stack: ${{ fromJson(needs.changes.outputs.stacks) }}
     steps:
       # Cannot pin by digest: Renovate will manage action updates
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Motivation

The Deploy workflow on the previous merge (PR #104) hit \`startup_failure\` 0s into the run with zero jobs created. The cause: I tried to fold both \`push\` and \`workflow_dispatch\` into one workflow with a clever matrix expression \`fromJson(format('["{0}"]', github.event.inputs.stack))\`. On push events the inputs.stack value is null and the expression evaluates badly, so GitHub rejects the workflow before any job starts.

## Implementation information

- \`deploy.yml\` reverted to the simple push-only shape that we know parses cleanly: \`changes\` job runs paths-filter, \`deploy\` matrix consumes its output.
- New \`deploy-manual.yml\` carries the \`workflow_dispatch\` trigger with the same stack-to-playbook resolution. Concurrency group is \`deploy\` so manual and auto runs serialize against each other.