### PR TITLE
fix(actions): grant deploy.yml validate scopes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,8 @@ concurrency:
 permissions:
   contents: read
   actions: read
+  pull-requests: write
+  security-events: write
 
 jobs:
   validate:


### PR DESCRIPTION
## Motivation

Last two Deploy runs (PR #104 and PR #107 merges) hit \`startup_failure\` 0s in with zero jobs created. Cause: \`deploy.yml\` calls \`validate.yml\` via \`uses: ./.github/workflows/validate.yml\`, but the caller's permission scope was narrower than the called workflow's needs. validate.yml requires \`pull-requests: write\` (PR comments) and \`security-events: write\` (Trivy SARIF upload), and reusable workflows inherit the caller's permissions — narrower caller scope = whole workflow rejected at startup.

## Implementation information

Add \`pull-requests: write\` and \`security-events: write\` to \`deploy.yml\` permissions block. No other changes.