### PR TITLE
fix(media): drop chown on virtiofs data dirs

### DIFF
--- a/ansible/playbooks/deploy-media-stack.yml
+++ b/ansible/playbooks/deploy-media-stack.yml
@@ -22,13 +22,15 @@
         state: started
         enabled: true
 
+    # data_root is a VirtioFS mount from the proxmox host's ZFS dataset.
+    # chown is not permitted across the virtiofs boundary, so we only
+    # ensure directories exist with a safe mode; ownership is fixed on
+    # the host side.
     - name: Create data directories
       ansible.builtin.file:
         path: "{{ item }}"
         state: directory
         mode: '0755'
-        owner: "1000"
-        group: "1000"
       loop:
         - "{{ data_root }}"
         - "{{ data_root }}/jellyfin/config"


### PR DESCRIPTION
## Motivation

First Renovate-driven CD deploy of the jellyfin stack (PR #108) failed on the \`Create data directories\` task:

\`\`\`
chown failed: [Errno 1] Operation not permitted: b'/data'
\`\`\`

\`/data\` on the jellyfin LXC is a VirtioFS mount from the proxmox host's ZFS dataset (see CLAUDE.md). VirtioFS refuses chown across the FS boundary, so the playbook has been failing at this step every run — just invisible until CD surfaced it. The directories already exist with the right effective ownership from the initial LXC setup.

## Implementation information

Drop \`owner\` and \`group\` from the \`Create data directories\` task. Keep \`mode: '0755'\` (chmod works on virtiofs). Ansible can still ensure the tree exists; ownership stays as-is from the host.