### PR TITLE
fix(media): mkdir -p for virtiofs data dirs

### DIFF
--- a/ansible/playbooks/deploy-media-stack.yml
+++ b/ansible/playbooks/deploy-media-stack.yml
@@ -23,14 +23,13 @@
         enabled: true
 
     # data_root is a VirtioFS mount from the proxmox host's ZFS dataset.
-    # chown is not permitted across the virtiofs boundary, so we only
-    # ensure directories exist with a safe mode; ownership is fixed on
-    # the host side.
+    # chown/chmod across the virtiofs boundary returns EPERM, so we use
+    # `mkdir -p` with `creates:` — the command is skipped entirely if the
+    # dir already exists and never touches its mode or ownership.
     - name: Create data directories
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: '0755'
+      ansible.builtin.command:
+        cmd: "mkdir -p {{ item }}"
+        creates: "{{ item }}"
       loop:
         - "{{ data_root }}"
         - "{{ data_root }}/jellyfin/config"


### PR DESCRIPTION
## Motivation

My previous fix (PR #115) dropped \`owner:\`/\`group:\` but kept \`mode: '0755'\`. The next CD run still failed on the same dirs:

\`\`\`
Task failed: Module failed: [Errno 1] Operation not permitted: b'/data/media'
\`\`\`

chmod also fails across the virtiofs boundary when the stored mode differs from the requested one. The only operations virtiofs reliably permits are read/write/create — not metadata changes.

## Implementation information

Switch from \`ansible.builtin.file\` to \`ansible.builtin.command: mkdir -p\` with \`creates:\`. Existing dirs short-circuit the task entirely (no chmod attempt), missing dirs get created normally, metadata on the virtiofs side stays whatever the host set.