### PR TITLE
feat(net): split-horizon dns + traefik tls

### DIFF
--- a/ansible/docker-compose/adguard-stack.yml
+++ b/ansible/docker-compose/adguard-stack.yml
@@ -1,0 +1,19 @@
+---
+services:
+  adguardhome:
+    image: adguard/adguardhome:v0.107.66
+    container_name: adguardhome
+    restart: unless-stopped
+    ports:
+      - "53:53/tcp"
+      - "53:53/udp"
+      - "3000:3000/tcp"  # Web UI
+    volumes:
+      - /opt/adguard/work:/opt/adguardhome/work
+      - /opt/adguard/conf:/opt/adguardhome/conf
+    networks:
+      - adguard
+
+networks:
+  adguard:
+    driver: bridge

--- a/ansible/docker-compose/infrastructure-stack.yml
+++ b/ansible/docker-compose/infrastructure-stack.yml
@@ -8,9 +8,12 @@ services:
       - "80:80"
       - "443:443"
       - "8080:8080"  # Dashboard (internal only)
+    environment:
+      - CF_DNS_API_TOKEN=${CF_DNS_API_TOKEN}
     volumes:
       - /opt/traefik/traefik.yml:/etc/traefik/traefik.yml:ro
       - /opt/traefik/config/services.yml:/etc/traefik/services.yml:ro
+      - /opt/traefik/acme.json:/etc/traefik/acme.json
       - /var/log/traefik:/var/log/traefik
     networks:
       - infrastructure

--- a/ansible/docker-compose/traefik/services.yml
+++ b/ansible/docker-compose/traefik/services.yml
@@ -4,66 +4,90 @@ http:
     jellyfin:
       rule: "Host(`jellyfin.mskalski.dev`)"
       service: jellyfin
-      entryPoints: [web]
+      entryPoints: [web, websecure]
+      tls:
+        certResolver: cloudflare
+        domains:
+          - main: "*.mskalski.dev"
 
     jellyseerr:
       rule: "Host(`jellyseerr.mskalski.dev`)"
       service: jellyseerr
-      entryPoints: [web]
+      entryPoints: [web, websecure]
+      tls:
+        certResolver: cloudflare
 
     sonarr:
       rule: "Host(`sonarr.mskalski.dev`)"
       service: sonarr
-      entryPoints: [web]
+      entryPoints: [web, websecure]
       middlewares: [internal-whitelist]
+      tls:
+        certResolver: cloudflare
 
     radarr:
       rule: "Host(`radarr.mskalski.dev`)"
       service: radarr
-      entryPoints: [web]
+      entryPoints: [web, websecure]
       middlewares: [internal-whitelist]
+      tls:
+        certResolver: cloudflare
 
     prowlarr:
       rule: "Host(`prowlarr.mskalski.dev`)"
       service: prowlarr
-      entryPoints: [web]
+      entryPoints: [web, websecure]
       middlewares: [internal-whitelist]
+      tls:
+        certResolver: cloudflare
 
     immich:
       rule: "Host(`immich.mskalski.dev`)"
       service: immich
-      entryPoints: [web]
+      entryPoints: [web, websecure]
       middlewares: [internal-whitelist]
+      tls:
+        certResolver: cloudflare
 
     paperless:
       rule: "Host(`paperless.mskalski.dev`)"
       service: paperless
-      entryPoints: [web]
+      entryPoints: [web, websecure]
       middlewares: [internal-whitelist]
+      tls:
+        certResolver: cloudflare
 
     nextcloud:
       rule: "Host(`nextcloud.mskalski.dev`)"
       service: nextcloud
-      entryPoints: [web]
+      entryPoints: [web, websecure]
       middlewares: [internal-whitelist]
+      tls:
+        certResolver: cloudflare
 
     mixarr:
       rule: "Host(`mixarr.mskalski.dev`)"
       service: mixarr
-      entryPoints: [web]
+      entryPoints: [web, websecure]
       middlewares: [internal-whitelist]
+      tls:
+        certResolver: cloudflare
 
     lidify:
       rule: "Host(`lidify.mskalski.dev`)"
       service: lidify
-      entryPoints: [web]
+      entryPoints: [web, websecure]
       middlewares: [internal-whitelist]
+      tls:
+        certResolver: cloudflare
 
     synapse:
       rule: "Host(`synapse.mskalski.dev`)"
       service: synapse
-      entryPoints: [web]
+      entryPoints: [web, websecure]
       middlewares: [internal-whitelist]
+      tls:
+        certResolver: cloudflare
 
   services:
     jellyfin:
@@ -127,3 +151,4 @@ http:
         sourceRange:
           - "192.168.0.0/16"
           - "172.16.0.0/12"  # Cloudflare Tunnel connector
+          - "100.64.0.0/10"  # Tailscale CGNAT

--- a/ansible/docker-compose/traefik/traefik.yml
+++ b/ansible/docker-compose/traefik/traefik.yml
@@ -23,6 +23,17 @@ providers:
     filename: /etc/traefik/services.yml
     watch: true
 
+certificatesResolvers:
+  cloudflare:
+    acme:
+      email: skalskimarcin33@gmail.com
+      storage: /etc/traefik/acme.json
+      dnsChallenge:
+        provider: cloudflare
+        resolvers:
+          - 1.1.1.1:53
+          - 8.8.8.8:53
+
 log:
   level: INFO
 

--- a/ansible/playbooks/deploy-adguard.yml
+++ b/ansible/playbooks/deploy-adguard.yml
@@ -1,0 +1,185 @@
+---
+# Deploy AdGuard Home on infrastructure LXC.
+# Provides network-wide DNS + ad-blocking + split-horizon rewrites so
+# *.mskalski.dev resolves to the internal Traefik IP (192.168.10.222)
+# for on-LAN and tailnet clients, while public DNS still routes external
+# requests through the Cloudflared tunnel.
+#
+# Manual follow-ups after first run:
+#   1. UDM Pro: Settings -> Networks -> [each VLAN] -> Advanced -> DHCP Service
+#      -> DNS Server -> 192.168.10.222
+#   2. Tailscale Admin -> DNS -> Nameservers -> Custom -> 192.168.10.222,
+#      restrict to domain mskalski.dev (Split DNS)
+
+- name: Deploy AdGuard Home DNS + ad-blocker
+  hosts: infrastructure
+  become: true
+
+  vars:
+    compose_file: /opt/adguard/docker-compose.yml
+    adguard_config_dir: /opt/adguard/conf
+    adguard_work_dir: /opt/adguard/work
+    traefik_lan_ip: 192.168.10.222
+    adguard_dns_rewrites:
+      - domain: jellyfin.mskalski.dev
+        answer: "{{ traefik_lan_ip }}"
+      - domain: jellyseerr.mskalski.dev
+        answer: "{{ traefik_lan_ip }}"
+      - domain: sonarr.mskalski.dev
+        answer: "{{ traefik_lan_ip }}"
+      - domain: radarr.mskalski.dev
+        answer: "{{ traefik_lan_ip }}"
+      - domain: prowlarr.mskalski.dev
+        answer: "{{ traefik_lan_ip }}"
+      - domain: immich.mskalski.dev
+        answer: "{{ traefik_lan_ip }}"
+      - domain: paperless.mskalski.dev
+        answer: "{{ traefik_lan_ip }}"
+      - domain: nextcloud.mskalski.dev
+        answer: "{{ traefik_lan_ip }}"
+      - domain: mixarr.mskalski.dev
+        answer: "{{ traefik_lan_ip }}"
+      - domain: lidify.mskalski.dev
+        answer: "{{ traefik_lan_ip }}"
+      - domain: synapse.mskalski.dev
+        answer: "{{ traefik_lan_ip }}"
+
+  handlers:
+    - name: Restart systemd-resolved
+      ansible.builtin.systemd:
+        name: systemd-resolved
+        state: restarted
+
+    - name: Restart AdGuard Home
+      community.docker.docker_container:
+        name: adguardhome
+        state: started
+        restart: true
+
+  tasks:
+    - name: Ensure Docker is running
+      ansible.builtin.systemd:
+        name: docker
+        state: started
+        enabled: true
+
+    - name: Ensure AdGuard directories exist
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: '0755'
+      loop:
+        - /opt/adguard
+        - "{{ adguard_config_dir }}"
+        - "{{ adguard_work_dir }}"
+
+    - name: Ensure systemd-resolved drop-in directory exists
+      ansible.builtin.file:
+        path: /etc/systemd/resolved.conf.d
+        state: directory
+        mode: '0755'
+        owner: root
+        group: root
+
+    - name: Disable systemd-resolved stub listener (frees :53)
+      ansible.builtin.copy:
+        content: |
+          [Resolve]
+          DNSStubListener=no
+        dest: /etc/systemd/resolved.conf.d/99-disable-stub.conf
+        mode: '0644'
+        owner: root
+        group: root
+      notify: Restart systemd-resolved
+
+    - name: Flush handlers so :53 is free before docker bind
+      ansible.builtin.meta: flush_handlers
+
+    - name: Extract AdGuard admin user from sops
+      ansible.builtin.command: >
+        sops -d --extract '["adguard_admin_user"]'
+        {{ playbook_dir }}/../secrets/secrets.yaml
+      register: adguard_user_result
+      delegate_to: localhost
+      become: false
+      no_log: true
+      changed_when: false
+
+    - name: Extract AdGuard admin password from sops
+      ansible.builtin.command: >
+        sops -d --extract '["adguard_admin_password"]'
+        {{ playbook_dir }}/../secrets/secrets.yaml
+      register: adguard_password_result
+      delegate_to: localhost
+      become: false
+      no_log: true
+      changed_when: false
+
+    - name: Set AdGuard credential facts
+      ansible.builtin.set_fact:
+        adguard_admin_user: "{{ adguard_user_result.stdout }}"
+        adguard_admin_password: "{{ adguard_password_result.stdout }}"
+      no_log: true
+
+    - name: Generate bcrypt hash of AdGuard admin password
+      ansible.builtin.command:
+        cmd: >-
+          python3 -c "import sys, bcrypt;
+          pw=sys.stdin.buffer.read().rstrip(b'\n')[:72];
+          print(bcrypt.hashpw(pw, bcrypt.gensalt(10)).decode())"
+        stdin: "{{ adguard_admin_password }}"
+      register: adguard_pw_hash_result
+      delegate_to: localhost
+      become: false
+      no_log: true
+      changed_when: false
+
+    - name: Set AdGuard password hash fact
+      ansible.builtin.set_fact:
+        adguard_admin_password_hash: "{{ adguard_pw_hash_result.stdout }}"
+      no_log: true
+
+    - name: Render AdGuard Home config
+      ansible.builtin.template:
+        src: templates/AdGuardHome.yaml.j2
+        dest: "{{ adguard_config_dir }}/AdGuardHome.yaml"
+        mode: '0600'
+        owner: root
+        group: root
+      no_log: true
+      notify: Restart AdGuard Home
+
+    - name: Copy AdGuard docker-compose file
+      ansible.builtin.copy:
+        src: ../docker-compose/adguard-stack.yml
+        dest: "{{ compose_file }}"
+        mode: '0644'
+
+    - name: Deploy AdGuard stack
+      community.docker.docker_compose_v2:
+        project_src: /opt/adguard
+        state: present
+        pull: always
+
+    - name: Flush handlers so config changes take effect before verify
+      ansible.builtin.meta: flush_handlers
+
+    - name: Verify AdGuard is running
+      community.docker.docker_container_info:
+        name: adguardhome
+      register: adguard_info
+      failed_when:
+        - not adguard_info.exists
+        - adguard_info.container.State.Status != 'running'
+
+    - name: Wait for AdGuard DNS port
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: 53
+        timeout: 30
+
+    - name: Wait for AdGuard web UI
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: 3000
+        timeout: 30

--- a/ansible/playbooks/deploy-infrastructure-stack.yml
+++ b/ansible/playbooks/deploy-infrastructure-stack.yml
@@ -25,6 +25,15 @@
         - /opt/traefik/config
         - /var/log/traefik
 
+    - name: Ensure acme.json exists with restrictive permissions
+      ansible.builtin.file:
+        path: /opt/traefik/acme.json
+        state: touch
+        mode: '0600'
+        owner: root
+        group: root
+      changed_when: false
+
     - name: Copy Traefik static config
       ansible.builtin.copy:
         src: ../docker-compose/traefik/traefik.yml
@@ -44,24 +53,36 @@
         mode: '0644'
 
     - name: Extract Cloudflare tunnel token from sops
-      ansible.builtin.shell: |
-        set -o pipefail
-        sops -d --extract '["cloudflare_tunnel_token"]' {{ playbook_dir }}/../secrets/secrets.yaml
+      ansible.builtin.command: >
+        sops -d --extract '["cloudflare_tunnel_token"]'
+        {{ playbook_dir }}/../secrets/secrets.yaml
       register: cf_token_result
       delegate_to: localhost
       become: false
       no_log: true
       changed_when: false
 
-    - name: Set Cloudflare tunnel token fact
+    - name: Extract Cloudflare DNS API token from sops
+      ansible.builtin.command: >
+        sops -d --extract '["cloudflare_dns_api_token"]'
+        {{ playbook_dir }}/../secrets/secrets.yaml
+      register: cf_dns_token_result
+      delegate_to: localhost
+      become: false
+      no_log: true
+      changed_when: false
+
+    - name: Set Cloudflare token facts
       ansible.builtin.set_fact:
         cf_tunnel_token: "{{ cf_token_result.stdout }}"
+        cf_dns_api_token: "{{ cf_dns_token_result.stdout }}"
       no_log: true
 
-    - name: Create .env file with Cloudflare tunnel token
+    - name: Create .env file with Cloudflare tokens
       ansible.builtin.copy:
         content: |
           CLOUDFLARE_TUNNEL_TOKEN={{ cf_tunnel_token }}
+          CF_DNS_API_TOKEN={{ cf_dns_api_token }}
         dest: "{{ env_file }}"
         mode: '0600'
       no_log: true

--- a/ansible/playbooks/deploy-tailscale.yml
+++ b/ansible/playbooks/deploy-tailscale.yml
@@ -1,0 +1,126 @@
+---
+# Deploy Tailscale subnet router on Proxmox host.
+# Exposes home-lab LAN (VLANs 10/20/40 + mgmt) to tailnet as single node
+# "klaudiusz-smart-home". Advertised routes must be approved once in the
+# Tailscale admin console (Machines -> klaudiusz-smart-home -> Edit route settings).
+
+- name: Deploy Tailscale subnet router
+  hosts: proxmox
+  become: true
+  gather_facts: true
+
+  vars:
+    tailscale_hostname: klaudiusz-smart-home
+    tailscale_routes:
+      - 192.168.0.0/24
+      - 192.168.10.0/24
+      - 192.168.20.0/24
+      - 192.168.40.0/24
+    tailscale_apt_base: https://pkgs.tailscale.com/stable/debian
+
+  handlers:
+    - name: Refresh apt cache
+      ansible.builtin.apt:
+        update_cache: true
+
+  tasks:
+    - name: Enable IPv4 forwarding
+      ansible.posix.sysctl:
+        name: net.ipv4.ip_forward
+        value: '1'
+        sysctl_set: true
+        state: present
+        reload: true
+
+    - name: Enable IPv6 forwarding
+      ansible.posix.sysctl:
+        name: net.ipv6.conf.all.forwarding
+        value: '1'
+        sysctl_set: true
+        state: present
+        reload: true
+
+    - name: Add Tailscale apt signing key
+      ansible.builtin.get_url:
+        url: "{{ tailscale_apt_base }}/{{ ansible_facts['distribution_release'] }}.noarmor.gpg"
+        dest: /usr/share/keyrings/tailscale-archive-keyring.gpg
+        mode: '0644'
+        owner: root
+        group: root
+      notify: Refresh apt cache
+
+    - name: Add Tailscale apt repository
+      ansible.builtin.get_url:
+        url: "{{ tailscale_apt_base }}/{{ ansible_facts['distribution_release'] }}.tailscale-keyring.list"
+        dest: /etc/apt/sources.list.d/tailscale.list
+        mode: '0644'
+        owner: root
+        group: root
+      notify: Refresh apt cache
+
+    - name: Flush handlers before install
+      ansible.builtin.meta: flush_handlers
+
+    - name: Install Tailscale
+      ansible.builtin.apt:
+        name: tailscale
+        state: present
+        cache_valid_time: 3600
+
+    - name: Ensure tailscaled is running and enabled
+      ansible.builtin.systemd:
+        name: tailscaled
+        state: started
+        enabled: true
+
+    - name: Extract Tailscale auth key from sops
+      ansible.builtin.command: >
+        sops -d --extract '["tailscale_authkey"]'
+        {{ playbook_dir }}/../secrets/secrets.yaml
+      register: ts_authkey_result
+      delegate_to: localhost
+      become: false
+      no_log: true
+      changed_when: false
+
+    - name: Check current Tailscale backend state
+      ansible.builtin.command: tailscale status --json
+      register: ts_status
+      changed_when: false
+      failed_when: false
+
+    - name: Parse Tailscale backend state
+      ansible.builtin.set_fact:
+        ts_backend_state: >-
+          {{ (ts_status.stdout | from_json).BackendState
+             if ts_status.rc == 0 and ts_status.stdout | length > 0
+             else 'NoState' }}
+
+    - name: Bring up Tailscale (first-time auth)
+      ansible.builtin.command: >
+        tailscale up
+        --authkey={{ ts_authkey_result.stdout }}
+        --hostname={{ tailscale_hostname }}
+        --advertise-routes={{ tailscale_routes | join(',') }}
+        --accept-dns=false
+      when: ts_backend_state != 'Running'
+      no_log: true
+      changed_when: true
+
+    - name: Update Tailscale settings (when already running)
+      ansible.builtin.command: >
+        tailscale set
+        --hostname={{ tailscale_hostname }}
+        --advertise-routes={{ tailscale_routes | join(',') }}
+        --accept-dns=false
+      when: ts_backend_state == 'Running'
+      changed_when: false
+
+    - name: Get final Tailscale status
+      ansible.builtin.command: tailscale status
+      register: ts_status_final
+      changed_when: false
+
+    - name: Display Tailscale status
+      ansible.builtin.debug:
+        var: ts_status_final.stdout_lines

--- a/ansible/playbooks/templates/AdGuardHome.yaml.j2
+++ b/ansible/playbooks/templates/AdGuardHome.yaml.j2
@@ -1,0 +1,194 @@
+http:
+  address: 0.0.0.0:3000
+  session_ttl: 720h
+users:
+  - name: {{ adguard_admin_user }}
+    password: {{ adguard_admin_password_hash }}
+auth_attempts: 5
+block_auth_min: 15
+http_proxy: ""
+language: en
+theme: auto
+dns:
+  bind_hosts:
+    - 0.0.0.0
+  port: 53
+  anonymize_client_ip: false
+  protection_enabled: true
+  blocking_mode: default
+  blocking_ipv4: ""
+  blocking_ipv6: ""
+  blocked_response_ttl: 10
+  parental_block_host: family-block.dns.adguard.com
+  safebrowsing_block_host: standard-block.dns.adguard.com
+  ratelimit: 0
+  ratelimit_subnet_len_ipv4: 24
+  ratelimit_subnet_len_ipv6: 56
+  ratelimit_whitelist: []
+  refuse_any: true
+  upstream_dns:
+    - https://1.1.1.1/dns-query
+    - https://9.9.9.9/dns-query
+    - https://dns.google/dns-query
+  upstream_dns_file: ""
+  bootstrap_dns:
+    - 1.1.1.1
+    - 9.9.9.9
+    - 8.8.8.8
+  fallback_dns: []
+  all_servers: false
+  fastest_addr: false
+  fastest_timeout: 1s
+  allowed_clients: []
+  disallowed_clients: []
+  blocked_hosts:
+    - version.bind
+    - id.server
+    - hostname.bind
+  trusted_proxies:
+    - 127.0.0.0/8
+    - ::1/128
+  cache_size: 4194304
+  cache_ttl_min: 0
+  cache_ttl_max: 0
+  cache_optimistic: false
+  bogus_nxdomain: []
+  aaaa_disabled: false
+  enable_dnssec: false
+  edns_client_subnet:
+    custom_ip: ""
+    enabled: false
+    use_custom: false
+  max_goroutines: 300
+  handle_ddr: true
+  ipset: []
+  ipset_file: ""
+  bootstrap_prefer_ipv6: false
+  upstream_timeout: 10s
+  private_networks: []
+  use_private_ptr_resolvers: true
+  local_ptr_upstreams: []
+  use_dns64: false
+  dns64_prefixes: []
+  serve_http3: false
+  use_http3_upstreams: false
+  serve_plain_dns: true
+  hostsfile_enabled: true
+tls:
+  enabled: false
+  server_name: ""
+  force_https: false
+  port_https: 443
+  port_dns_over_tls: 853
+  port_dns_over_quic: 853
+  port_dnscrypt: 0
+  dnscrypt_config_file: ""
+  allow_unencrypted_doh: false
+  certificate_chain: ""
+  private_key: ""
+  certificate_path: ""
+  private_key_path: ""
+  strict_sni_check: false
+querylog:
+  dir_path: ""
+  ignored: []
+  interval: 2160h
+  size_memory: 1000
+  enabled: true
+  file_enabled: true
+statistics:
+  dir_path: ""
+  ignored: []
+  interval: 24h
+  enabled: true
+filters:
+  - enabled: true
+    url: https://adguardteam.github.io/HostlistsRegistry/assets/filter_1.txt
+    name: AdGuard DNS filter
+    id: 1
+  - enabled: true
+    url: https://adguardteam.github.io/HostlistsRegistry/assets/filter_2.txt
+    name: AdAway Default Blocklist
+    id: 2
+  - enabled: true
+    url: https://easylist.to/easylist/easylist.txt
+    name: EasyList
+    id: 3
+whitelist_filters: []
+user_rules: []
+dhcp:
+  enabled: false
+  interface_name: ""
+  local_domain_name: lan
+  dhcpv4:
+    gateway_ip: ""
+    subnet_mask: ""
+    range_start: ""
+    range_end: ""
+    lease_duration: 86400
+    icmp_timeout_msec: 1000
+    options: []
+  dhcpv6:
+    range_start: ""
+    lease_duration: 86400
+    ra_slaac_only: false
+    ra_allow_slaac: false
+filtering:
+  blocking_ipv4: ""
+  blocking_ipv6: ""
+  blocked_services:
+    schedule:
+      time_zone: Local
+    ids: []
+  protection_disabled_until: null
+  safe_search:
+    enabled: false
+    bing: true
+    duckduckgo: true
+    ecosia: true
+    google: true
+    pixabay: true
+    yandex: true
+    youtube: true
+  blocking_mode: default
+  parental_block_host: family-block.dns.adguard.com
+  safebrowsing_block_host: standard-block.dns.adguard.com
+  rewrites:
+{% for rewrite in adguard_dns_rewrites %}
+    - domain: {{ rewrite.domain }}
+      answer: {{ rewrite.answer }}
+{% endfor %}
+  safe_fs_patterns:
+    - /opt/adguardhome/work/data/userfilters/*
+  safebrowsing_cache_size: 1048576
+  safesearch_cache_size: 1048576
+  parental_cache_size: 1048576
+  cache_time: 30
+  filters_update_interval: 24
+  blocked_response_ttl: 10
+  filtering_enabled: true
+  parental_enabled: false
+  safebrowsing_enabled: false
+  protection_enabled: true
+clients:
+  runtime_sources:
+    whois: true
+    arp: true
+    rdns: true
+    dhcp: true
+    hosts: true
+  persistent: []
+log:
+  enabled: true
+  file: ""
+  max_backups: 0
+  max_size: 100
+  max_age: 3
+  compress: false
+  local_time: false
+  verbose: false
+os:
+  group: ""
+  user: ""
+  rlimit_nofile: 0
+schema_version: 28

--- a/ansible/secrets/secrets.yaml
+++ b/ansible/secrets/secrets.yaml
@@ -17,6 +17,9 @@ lidarr_api_key: ENC[AES256_GCM,data:e5wWgsYgI2ATKkVOtxLdXb4ntWJZR3IHlyDocNo7rRo=
 prowlarr_api_key: ENC[AES256_GCM,data:iDnZ04xxDUFm/omGM+HvkjsHpEltkzyt/hTt2O+ZJe0=,iv:Knt9nxYKGzGyUiZKzBeAPTwbRalf+dGVfu4khKBvlco=,tag:lQeHigw5S/S1VZNIb/IJzw==,type:str]
 bazarr_api_key: ENC[AES256_GCM,data:673LYSaYYsmmIwmXbaVtWQbV/uTTBt+7JbSFbiO8yMA=,iv:gbhV5/gym/5SJBmpczqNYNY+8wx6rWD7syaXVPzclx8=,tag:Nr+YqbfH42CcO/hACimSxw==,type:str]
 tailscale_authkey: ENC[AES256_GCM,data:fdNB0S1GH7rwhwJrVuZlSIFoonhX2IqwH6W3ABHc8Q+wMXJrcZ5ke8IeRR4zzexudc3EqnmNXCjXxTr3Iis=,iv:yBONFgxcEbn5pwS7Ug7iJ7kD3v3VovHpuNvSuQ/WRvg=,tag:MM8XqHfbYcskfrnT/SmgFQ==,type:str]
+adguard_admin_user: ENC[AES256_GCM,data:u4YSdYN46OE=,iv:pUX1VaI+XiYjsNUGvGCQAbQirp2jWv4kJgL+AoKqOHs=,tag:yAv4LFtk9POLfLpTjwZOaA==,type:str]
+adguard_admin_password: ENC[AES256_GCM,data:tk7f+RfmiaT68PeJ80Wj6yWeV95Rba8+2g==,iv:l0EnIas4vIe6tB5oMvOuLrkXweM8hnKjBJzj8IGwINc=,tag:u4W80ZZNGyHh+OeZJo7hMQ==,type:str]
+cloudflare_dns_api_token: ENC[AES256_GCM,data:pfmBo/dWCfWw+yLXix1W9cjRYGvvLc8JK/0xP9sOzG3PiOpF5X3Y+wCSo4BK+jYynGO6zQg=,iv:ZDIQsLyOA4PnKhuF9yb2HY62frrYOrjiqZ2kRy/8CEg=,tag:eC+sb2lDjuFtSubUvXsUcQ==,type:str]
 sops:
     age:
         - recipient: age1kfklkd3xuacvfu0gy35v7cwk5lw8y9xv0lr5hs2ddyn82ww9mdlslfth6h
@@ -37,7 +40,7 @@ sops:
             Q0dwbTZJaUpRbVVzWmlGRGxZdXJpMzQKWCWSoy6+0qiWqkrJXgHLpCN2WTE3oSEk
             mYfd6+zHm7e+8VOMDHejDgoqkPSwIOCy24ZcflfNQULiOpPXiS1/lQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-13T08:20:46Z"
-    mac: ENC[AES256_GCM,data:pPKstpbfM162SMlK/Egyz9wmg/HUEvm2Zzs02wnJ8xk+qGSmzfT2Nsl/5ejwaphT5bxZLgEhlWGgvUW1tuaB0bCscYCDmZ6ZNtBq4RUQtfy1/bP2di6M4xLpTxDX09Sj9rL4mRmcd6KjezyBhQVph2IESl1Is1pdMSEgFOl+1/8=,iv:BnJfDhQJrqfLsrCjSNH+v1ieqEvrmfofj3BJipKVgo8=,tag:DrSRvq7K07QnfN0kLCxJaQ==,type:str]
+    lastmodified: "2026-04-13T10:06:00Z"
+    mac: ENC[AES256_GCM,data:VTjNEkz+5orJLG4jU4SjtLMOaOKoo6abUjwDFQN5PO2C84kItzeFOspLMAqzzhwXRK80K8JdLAJ9QcNmpInnl6eNDDDbk0xBvdT+6RhtiCIHij2fJdyn9FrYAuxxNG5pJ1XZb1zJvljkJ//BSdj7MgOvic+F2+lQINvH8DFJ1nA=,iv:QOEt8oZ61aEXFOUWs5N01Wu0x2BmdesYIsm9Wj1oeMg=,tag:7ZB4htwN6coTp5DGC34eVg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/ansible/secrets/secrets.yaml
+++ b/ansible/secrets/secrets.yaml
@@ -16,6 +16,7 @@ radarr_api_key: ENC[AES256_GCM,data:2Mudx+llSg5B6FX80qFCvYALlyhXIdtb/JpgZitSPG0=
 lidarr_api_key: ENC[AES256_GCM,data:e5wWgsYgI2ATKkVOtxLdXb4ntWJZR3IHlyDocNo7rRo=,iv:pl3jrusHMJPyEKUXLZ69TwRvRqc1F1PJUyFve79pejQ=,tag:6n4kNssQJmj3v9vWAYH60Q==,type:str]
 prowlarr_api_key: ENC[AES256_GCM,data:iDnZ04xxDUFm/omGM+HvkjsHpEltkzyt/hTt2O+ZJe0=,iv:Knt9nxYKGzGyUiZKzBeAPTwbRalf+dGVfu4khKBvlco=,tag:lQeHigw5S/S1VZNIb/IJzw==,type:str]
 bazarr_api_key: ENC[AES256_GCM,data:673LYSaYYsmmIwmXbaVtWQbV/uTTBt+7JbSFbiO8yMA=,iv:gbhV5/gym/5SJBmpczqNYNY+8wx6rWD7syaXVPzclx8=,tag:Nr+YqbfH42CcO/hACimSxw==,type:str]
+tailscale_authkey: ENC[AES256_GCM,data:fdNB0S1GH7rwhwJrVuZlSIFoonhX2IqwH6W3ABHc8Q+wMXJrcZ5ke8IeRR4zzexudc3EqnmNXCjXxTr3Iis=,iv:yBONFgxcEbn5pwS7Ug7iJ7kD3v3VovHpuNvSuQ/WRvg=,tag:MM8XqHfbYcskfrnT/SmgFQ==,type:str]
 sops:
     age:
         - recipient: age1kfklkd3xuacvfu0gy35v7cwk5lw8y9xv0lr5hs2ddyn82ww9mdlslfth6h
@@ -36,7 +37,7 @@ sops:
             Q0dwbTZJaUpRbVVzWmlGRGxZdXJpMzQKWCWSoy6+0qiWqkrJXgHLpCN2WTE3oSEk
             mYfd6+zHm7e+8VOMDHejDgoqkPSwIOCy24ZcflfNQULiOpPXiS1/lQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-09T15:24:49Z"
-    mac: ENC[AES256_GCM,data:qfxmOxiCMWj6EXwEWjjZiv058/snmD3s73p5eOezsthClx42KBGWyNX3ldu2+9pK5zqVtlW9q81IzIBIqVwKPYxjWCd6ylEAMXXgBwXLmBCxEDDwOFbzWYn5yvo9T/qYZE6TXHW0vHATIDxgf2PzQLMMdLRx9J8r4zp7JyvSCBE=,iv:619te75qA01de8rQ6Gq7+NPCunrspW33ZClR+wtQtS8=,tag:5QupaGtijwWkpueRyo+n8A==,type:str]
+    lastmodified: "2026-04-13T08:20:46Z"
+    mac: ENC[AES256_GCM,data:pPKstpbfM162SMlK/Egyz9wmg/HUEvm2Zzs02wnJ8xk+qGSmzfT2Nsl/5ejwaphT5bxZLgEhlWGgvUW1tuaB0bCscYCDmZ6ZNtBq4RUQtfy1/bP2di6M4xLpTxDX09Sj9rL4mRmcd6KjezyBhQVph2IESl1Is1pdMSEgFOl+1/8=,iv:BnJfDhQJrqfLsrCjSNH+v1ieqEvrmfofj3BJipKVgo8=,tag:DrSRvq7K07QnfN0kLCxJaQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0


### PR DESCRIPTION
## Motivation

Goal: same `*.mskalski.dev` URLs work everywhere — at home, on the
tailnet, and from the public internet — taking the fastest direct
path each time.

Today every request to `jellyfin.mskalski.dev` (and the other 10
services routed by Traefik) goes through Cloudflare → cloudflared
tunnel → Traefik, even when the client is sitting on the same LAN.
That adds latency and creates a hard dependency on the public path.

`.dev` is an HSTS-preloaded TLD, so plain HTTP fallback on the
internal network is impossible — browsers force HTTPS regardless of
headers. Internal access therefore needs a real, trusted TLS cert
on Traefik plus an internal DNS server that knows to point clients
at the LAN IP.

## Implementation information

Two-phase rollout.

**Phase 1 — Traefik TLS** (`feat(traefik): wildcard tls via le dns-01`)
- Add `websecure:443` entrypoint
- Add `certificatesResolvers.cloudflare` using Let's Encrypt DNS-01
  challenge against the Cloudflare API
- Wildcard `*.mskalski.dev` cert auto-issues and auto-renews
- All routers updated to `[web, websecure]` with `tls.certResolver`
- `internal-whitelist` middleware extended with the Tailscale CGNAT
  range (`100.64.0.0/10`) so tailnet clients don't trip the IP allow
  list
- New sops secret `cloudflare_dns_api_token`, written to `.env` and
  injected as `CF_DNS_API_TOKEN` in the traefik container
- New `acme.json` volume (mode 0600) for cert state

**Phase 2 — AdGuard Home** (`feat(adguard): split-horizon dns + ad-block`)
- New playbook `deploy-adguard.yml` targeting the infrastructure LXC
  alongside Traefik
- New compose stack `adguard-stack.yml` (bridge net, ports 53/3000)
- Pre-seeded `AdGuardHome.yaml` via Jinja2 template:
  - bcrypt admin hash generated locally from the sops password
  - 11 DNS rewrites — every Traefik-routed `*.mskalski.dev` host
    points at `192.168.10.222` (the Traefik LAN IP)
  - 3 default filter lists enabled (AdGuard DNS, AdAway, EasyList)
  - Cloudflare + Quad9 + Google as upstream DoH
- Disables `systemd-resolved` stub listener to free port 53
- New sops secrets `adguard_admin_user`, `adguard_admin_password`

**Manual steps required after merge** (already done in the live env):
1. UDM Pro: hand out `192.168.10.222` as DHCP DNS on each VLAN
2. UDM Pro: set `192.168.10.222` as the WAN/upstream DNS so that
   gateway-intercepted queries are also forwarded to AdGuard
3. Tailscale Admin → DNS → Split DNS → `192.168.10.222` for
   `mskalski.dev`

**Verification (from this session):**
- Wildcard cert issued (`subject=CN = *.mskalski.dev`,
  `issuer=Let's Encrypt R13`)
- `dig jellyfin.mskalski.dev` from a LAN client returns
  `192.168.10.222`
- `curl -sI https://jellyfin.mskalski.dev` returns
  `server: Kestrel` with no `cf-ray` header — direct path to Traefik
- Ad-block confirmed (`doubleclick.net` → AdGuard `0.0.0.0`)
- Public passthrough confirmed (`github.com` → real IP)

## Supporting documentation

- Tailscale subnet router `klaudiusz-smart-home` shipped earlier
  (commit `3c2eba2`)
- `home-lab-doc/services/inventory.md` updated in the docs repo to
  list AdGuard on the infrastructure LXC (separate PR)