### PR TITLE
feat(adguard): schema 33 + ci auto-deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,10 @@ jobs:
               - 'ansible/docker-compose/infrastructure-stack.yml'
               - 'ansible/docker-compose/traefik/**'
               - 'ansible/playbooks/deploy-infrastructure-stack.yml'
+            adguard:
+              - 'ansible/docker-compose/adguard-stack.yml'
+              - 'ansible/playbooks/deploy-adguard.yml'
+              - 'ansible/playbooks/templates/AdGuardHome.yaml.j2'
             media-management:
               - 'ansible/docker-compose/media-management-stack.yml'
               - 'ansible/playbooks/deploy-media-management.yml'
@@ -84,6 +88,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-ansible-collections-
 
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+
       - name: Install Ansible collections
         run: ansible-galaxy collection install -r ansible/requirements.yml
 
@@ -92,6 +99,7 @@ jobs:
         run: |
           case "${{ matrix.stack }}" in
             infrastructure)     pb=deploy-infrastructure-stack.yml; lim=infrastructure ;;
+            adguard)            pb=deploy-adguard.yml;              lim=infrastructure ;;
             media-management)   pb=deploy-media-management.yml;     lim=media-management ;;
             jellyfin)           pb=deploy-media-stack.yml;          lim=jellyfin ;;
             immich)             pb=deploy-immich.yml;               lim=jellyfin ;;

--- a/ansible/docker-compose/adguard-stack.yml
+++ b/ansible/docker-compose/adguard-stack.yml
@@ -1,7 +1,7 @@
 ---
 services:
   adguardhome:
-    image: adguard/adguardhome:v0.107.66
+    image: adguard/adguardhome:v0.107.73
     container_name: adguardhome
     restart: unless-stopped
     ports:

--- a/ansible/playbooks/templates/AdGuardHome.yaml.j2
+++ b/ansible/playbooks/templates/AdGuardHome.yaml.j2
@@ -52,6 +52,8 @@ dns:
   cache_ttl_min: 0
   cache_ttl_max: 0
   cache_optimistic: false
+  cache_optimistic_answer_ttl: 30s
+  cache_optimistic_max_age: 12h
   bogus_nxdomain: []
   aaaa_disabled: false
   enable_dnssec: false
@@ -92,6 +94,7 @@ tls:
 querylog:
   dir_path: ""
   ignored: []
+  ignored_enabled: true
   interval: 2160h
   size_memory: 1000
   enabled: true
@@ -99,6 +102,7 @@ querylog:
 statistics:
   dir_path: ""
   ignored: []
+  ignored_enabled: true
   interval: 24h
   enabled: true
 filters:
@@ -153,10 +157,12 @@ filtering:
   blocking_mode: default
   parental_block_host: family-block.dns.adguard.com
   safebrowsing_block_host: standard-block.dns.adguard.com
+  rewrites_enabled: true
   rewrites:
 {% for rewrite in adguard_dns_rewrites %}
     - domain: {{ rewrite.domain }}
       answer: {{ rewrite.answer }}
+      enabled: true
 {% endfor %}
   safe_fs_patterns:
     - /opt/adguardhome/work/data/userfilters/*
@@ -191,4 +197,4 @@ os:
   group: ""
   user: ""
   rlimit_nofile: 0
-schema_version: 28
+schema_version: 33

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 ansible-lint==26.4.0
 yamllint==1.38.0
+passlib==1.7.4
+bcrypt==5.0.0


### PR DESCRIPTION
## Motivation

Two follow-ups to PR #117 surfaced after merge.

1. Renovate opened #118 bumping `adguard/adguardhome` from
   `v0.107.66` to `v0.107.73`. That range spans **3 schema_version
   bumps** (28 → 33), and the AdGuardHome.yaml.j2 template hard-codes
   schema 28. Merging the bump alone would put us in a loop where
   AdGuard auto-migrates on container start, then ansible re-renders
   the template with schema 28 on the next run, forcing a fresh
   migration on the next restart.

2. PR #117's auto-deploy did not run for AdGuard because the stack
   wasn't in the deploy workflow's path filter. Worse, the deploy job
   doesn't `pip install` anything, so even if AdGuard were wired into
   CI the `password_hash` filter would fail (passlib + bcrypt missing
   on the runner).

This PR supersedes Renovate #118.

## Implementation information

**Schema migration** (`feat(adguard): bump v0.107.73 + schema 33`)
- `schema_version: 28` → `33`
- New fields:
  - `filtering.rewrites_enabled: true` and per-rewrite `enabled: true`
    (schema 31, v0.107.68)
  - `dns.cache_optimistic_answer_ttl: 30s` and
    `dns.cache_optimistic_max_age: 12h` (schema 32, v0.107.71)
  - `querylog.ignored_enabled: true` and
    `statistics.ignored_enabled: true` (schema 33, v0.107.72)
- `adguard-stack.yml` image tag bumped to `v0.107.73`
- v0.107.73 is a security fix (H2C upgrade auth bypass)

**CI integration** (`ci(actions): auto-deploy adguard + pin py deps`)
- New `adguard` entry in `dorny/paths-filter` matching:
  - `ansible/docker-compose/adguard-stack.yml`
  - `ansible/playbooks/deploy-adguard.yml`
  - `ansible/playbooks/templates/AdGuardHome.yaml.j2`
- New case branch in `Resolve playbook + limit` mapping `adguard`
  → `deploy-adguard.yml` on the `infrastructure` host
- New `pip install -r requirements.txt` step in the deploy job
  (validate job already had this — deploy didn't)
- `passlib==1.7.4` and `bcrypt==5.0.0` pinned in `requirements.txt`
  so the password_hash filter works on a fresh checkout

## Supporting documentation

- Renovate PR being superseded: #118
- AdGuard Home v0.107.67–v0.107.73 release notes:
  https://github.com/AdguardTeam/AdGuardHome/blob/master/CHANGELOG.md