### PR TITLE
fix(adguard): pre-hash bcrypt + drop pip step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,9 +88,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-ansible-collections-
 
-      - name: Install Python dependencies
-        run: pip install -r requirements.txt
-
       - name: Install Ansible collections
         run: ansible-galaxy collection install -r ansible/requirements.yml
 

--- a/ansible/playbooks/deploy-adguard.yml
+++ b/ansible/playbooks/deploy-adguard.yml
@@ -105,11 +105,11 @@
       no_log: true
       changed_when: false
 
-    - name: Extract AdGuard admin password from sops
+    - name: Extract AdGuard admin password hash from sops
       ansible.builtin.command: >
-        sops -d --extract '["adguard_admin_password"]'
+        sops -d --extract '["adguard_admin_password_hash"]'
         {{ playbook_dir }}/../secrets/secrets.yaml
-      register: adguard_password_result
+      register: adguard_pw_hash_result
       delegate_to: localhost
       become: false
       no_log: true
@@ -118,24 +118,6 @@
     - name: Set AdGuard credential facts
       ansible.builtin.set_fact:
         adguard_admin_user: "{{ adguard_user_result.stdout }}"
-        adguard_admin_password: "{{ adguard_password_result.stdout }}"
-      no_log: true
-
-    - name: Generate bcrypt hash of AdGuard admin password
-      ansible.builtin.command:
-        cmd: >-
-          python3 -c "import sys, bcrypt;
-          pw=sys.stdin.buffer.read().rstrip(b'\n')[:72];
-          print(bcrypt.hashpw(pw, bcrypt.gensalt(10)).decode())"
-        stdin: "{{ adguard_admin_password }}"
-      register: adguard_pw_hash_result
-      delegate_to: localhost
-      become: false
-      no_log: true
-      changed_when: false
-
-    - name: Set AdGuard password hash fact
-      ansible.builtin.set_fact:
         adguard_admin_password_hash: "{{ adguard_pw_hash_result.stdout }}"
       no_log: true
 

--- a/ansible/secrets/secrets.yaml
+++ b/ansible/secrets/secrets.yaml
@@ -20,6 +20,7 @@ tailscale_authkey: ENC[AES256_GCM,data:fdNB0S1GH7rwhwJrVuZlSIFoonhX2IqwH6W3ABHc8
 adguard_admin_user: ENC[AES256_GCM,data:u4YSdYN46OE=,iv:pUX1VaI+XiYjsNUGvGCQAbQirp2jWv4kJgL+AoKqOHs=,tag:yAv4LFtk9POLfLpTjwZOaA==,type:str]
 adguard_admin_password: ENC[AES256_GCM,data:tk7f+RfmiaT68PeJ80Wj6yWeV95Rba8+2g==,iv:l0EnIas4vIe6tB5oMvOuLrkXweM8hnKjBJzj8IGwINc=,tag:u4W80ZZNGyHh+OeZJo7hMQ==,type:str]
 cloudflare_dns_api_token: ENC[AES256_GCM,data:pfmBo/dWCfWw+yLXix1W9cjRYGvvLc8JK/0xP9sOzG3PiOpF5X3Y+wCSo4BK+jYynGO6zQg=,iv:ZDIQsLyOA4PnKhuF9yb2HY62frrYOrjiqZ2kRy/8CEg=,tag:eC+sb2lDjuFtSubUvXsUcQ==,type:str]
+adguard_admin_password_hash: ENC[AES256_GCM,data:EFcBc9Fa/Ov435c8OQDNqDAJltUj8oQLyplR8mlDiSfeBJbXs4iIG8wBTxRfBEXtjB0VB8EIfeoJlSUY,iv:7DpImqgUXZpKzWDhVh2Pq3qxku8GpBeXQhUaPPdFbuQ=,tag:OZhPTxDeVO0K7kJW/39g/g==,type:str]
 sops:
     age:
         - recipient: age1kfklkd3xuacvfu0gy35v7cwk5lw8y9xv0lr5hs2ddyn82ww9mdlslfth6h
@@ -40,7 +41,7 @@ sops:
             Q0dwbTZJaUpRbVVzWmlGRGxZdXJpMzQKWCWSoy6+0qiWqkrJXgHLpCN2WTE3oSEk
             mYfd6+zHm7e+8VOMDHejDgoqkPSwIOCy24ZcflfNQULiOpPXiS1/lQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-13T10:06:00Z"
-    mac: ENC[AES256_GCM,data:VTjNEkz+5orJLG4jU4SjtLMOaOKoo6abUjwDFQN5PO2C84kItzeFOspLMAqzzhwXRK80K8JdLAJ9QcNmpInnl6eNDDDbk0xBvdT+6RhtiCIHij2fJdyn9FrYAuxxNG5pJ1XZb1zJvljkJ//BSdj7MgOvic+F2+lQINvH8DFJ1nA=,iv:QOEt8oZ61aEXFOUWs5N01Wu0x2BmdesYIsm9Wj1oeMg=,tag:7ZB4htwN6coTp5DGC34eVg==,type:str]
+    lastmodified: "2026-04-13T10:46:36Z"
+    mac: ENC[AES256_GCM,data:ZIXTmBkYDvR8b6eL8SQr1NjMLuuUWK8SF2+8ZcY7xY65aF2YuSduNskvtsavrSTfWf5Nh33eNm4dkoYIG7FhGcXBbQfLZbVo8Gu9bIpmtgjnlr8IVPA2/Pw3Dgh3Y5gXEO8oyJ6v4i2Qy6hrLk14kBo80SjsJqpx6ncirG8JuDI=,iv:emSoR1CJn2HETF9901aap90Lt3Irc4ejZne+TlVzWZY=,tag:PMsX/ixR1F7rQ2eEK8rUZA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 ansible-lint==26.4.0
 yamllint==1.38.0
-passlib==1.7.4
-bcrypt==5.0.0


### PR DESCRIPTION
## Motivation

The auto-deploy step added in #119 immediately failed on the
self-hosted NixOS runner. Logs:

```
× This environment is externally managed
[error] Process completed with exit code 1.
```

`pip install -r requirements.txt` is blocked by PEP 668 on NixOS
because the system Python interpreter is provided as part of the
read-only nix profile. Even with `--break-system-packages`, the
installed modules wouldn't be found by the system Ansible's Python
interpreter.

Two paths considered:

1. Add `passlib` + `bcrypt` to the runner's nix `extraPackages`.
   Clean but requires a coordinated PR in `klaudiusz-smart-home`
   plus a manual `nixos-rebuild`.
2. Stop hashing at deploy time. Generate the bcrypt hash once
   locally, store it in sops, render it directly into the AdGuard
   config template.

This PR takes option 2 — single repo, no nix changes, simpler
playbook.

## Implementation information

- New sops key `adguard_admin_password_hash` (bcrypt cost 10,
  generated locally with the `bcrypt` Python package). The plaintext
  `adguard_admin_password` is kept for future reference but no
  longer consulted by the playbook.
- `deploy-adguard.yml` reads `adguard_admin_password_hash` from sops
  in a single task and passes it straight to the template fact.
  Removed the runtime hashing task entirely.
- `.github/workflows/deploy.yml` reverted: dropped the
  `pip install -r requirements.txt` step from the deploy job.
- `requirements.txt`: dropped `passlib` and `bcrypt` (no longer used
  by any deploy path; ansible-lint and yamllint remain).

## Verification

Re-ran `deploy-adguard.yml` against the live infrastructure LXC:

```
PLAY RECAP
infrastructure : ok=15  changed=4  unreachable=0  failed=0
```

Container is now `adguard/adguardhome:v0.107.73`, and
`dig @127.0.0.1 jellyfin.mskalski.dev` from inside the LXC still
returns `192.168.10.222` — rewrites and ad-blocking unchanged.

## Supporting documentation

- Failed run that triggered this fix: 24338953216
- PEP 668 background:
  https://peps.python.org/pep-0668/