### PR TITLE
chore(synapse): bump image to 0.6.0

### DIFF
--- a/ansible/docker-compose/synapse-stack.yml
+++ b/ansible/docker-compose/synapse-stack.yml
@@ -2,7 +2,7 @@
 services:
   synapse:
     container_name: synapse
-    image: ghcr.io/automaat/synapse:0.5.0
+    image: ghcr.io/automaat/synapse:0.6.0
     restart: unless-stopped
     ports:
       - "8080:8080"


### PR DESCRIPTION
Bumps synapse to 0.6.0 which now ships the klaudiush binary,
so the Claude/Codex hook configs deployed earlier will actually
execute inside the container.