### PR TITLE
chore(synapse): add PostToolUse hook for claude

### DIFF
--- a/ansible/playbooks/files/synapse/claude/settings.json
+++ b/ansible/playbooks/files/synapse/claude/settings.json
@@ -31,6 +31,18 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash|Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "klaudiush --hook-type PostToolUse --trace",
+            "timeout": 30
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
klaudiush doctor recommends pairing PreToolUse with a PostToolUse
entry so post-tool rule checks (formatters, linter-ignore
detection, etc.) fire after Bash/Write/Edit/MultiEdit runs.
Adds one matcher group to the claude settings.json.

> Changelog: skip