### PR TITLE
chore(synapse): bump image to 0.7.0

### DIFF
--- a/ansible/docker-compose/synapse-stack.yml
+++ b/ansible/docker-compose/synapse-stack.yml
@@ -2,7 +2,7 @@
 services:
   synapse:
     container_name: synapse
-    image: ghcr.io/automaat/synapse:0.6.0
+    image: ghcr.io/automaat/synapse:0.7.0
     restart: unless-stopped
     ports:
       - "8080:8080"


### PR DESCRIPTION
## Motivation

Pick up latest synapse release.

## Implementation information

Bump `ghcr.io/automaat/synapse` from `0.6.0` to `0.7.0` in `ansible/docker-compose/synapse-stack.yml`.

## Supporting documentation

N/A

> Changelog: skip