### PR TITLE
ci(actions): redeploy synapse on files/ change

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,6 +57,7 @@ jobs:
             synapse:
               - 'ansible/docker-compose/synapse-stack.yml'
               - 'ansible/playbooks/deploy-synapse.yml'
+              - 'ansible/playbooks/files/synapse/**'
             finance-buddy:
               - 'ansible/docker-compose/finance-buddy-stack.yml'
               - 'ansible/playbooks/deploy-finance-buddy.yml'


### PR DESCRIPTION
## Motivation

Synapse path filter only watched the compose file and playbook, so edits to `files/synapse/**` (klaudiush settings, global CLAUDE.md, AGENTS.md, hooks.json) would not trigger a redeploy. Easy to forget when updating just a config file.

## Implementation information

Added `ansible/playbooks/files/synapse/**` to the synapse filter in `deploy.yml`. Covers every fixture the deploy playbook ships into `/data/synapse/{claude,codex}/`.

## Supporting documentation

n/a

> Changelog: skip