### PR TITLE
feat(synapse): enable prometheus metrics in config

### DIFF
--- a/ansible/playbooks/deploy-synapse.yml
+++ b/ansible/playbooks/deploy-synapse.yml
@@ -7,6 +7,11 @@
     data_root: /data
     compose_file: /opt/synapse/docker-compose.yml
 
+  handlers:
+    - name: Restart synapse
+      ansible.builtin.command: docker restart synapse
+      changed_when: true
+
   tasks:
     - name: Install Docker and dependencies
       ansible.builtin.apt:
@@ -87,6 +92,16 @@
         mode: '0644'
         owner: "0"
         group: "0"
+
+    - name: Enable Prometheus metrics in synapse config
+      ansible.builtin.blockinfile:
+        path: "{{ data_root }}/synapse/home/config.yaml"
+        marker: "# {mark} ANSIBLE MANAGED BLOCK - metrics"
+        block: |
+          metrics:
+              enabled: true
+        create: false
+      notify: Restart synapse
 
     - name: Deploy synapse stack
       community.docker.docker_compose_v2:


### PR DESCRIPTION
## Motivation

Synapse exposes Prometheus metrics at `/metrics` but only when `metrics.enabled: true` is set in the config. Without this, the companion scrape job in `klaudiusz-smart-home` would hit an empty endpoint. This encodes the enable step in the deploy playbook so future redeploys don't regress.

## Implementation information

- Add `blockinfile` task that appends a `metrics: { enabled: true }` block to `/data/synapse/home/config.yaml` with an ansible-managed marker (idempotent, does not clobber the manually-added `todoist.api_token`).
- Add `Restart synapse` handler (`docker restart synapse`) triggered only on block change.
- Verified live on LXC CT 114: `curl http://192.168.20.219:8080/metrics` returns `synapse_*` series after restart.

## Supporting documentation

- Companion PR: Automaat/klaudiusz-smart-home#524 (prometheus scrape job + alert rules)
- Companion doc: `home-lab-doc/monitoring/prometheus-targets.md` entry