### PR TITLE
feat(traefik): add finance-buddy routes

### DIFF
--- a/ansible/docker-compose/finance-buddy-stack.yml
+++ b/ansible/docker-compose/finance-buddy-stack.yml
@@ -42,7 +42,7 @@ services:
     environment:
       DATABASE_URL: postgresql://finance:${FINANCE_DB_PASSWORD}@finance-postgres:5432/finance
       APP_PASSWORD: ${FINANCE_APP_PASSWORD}
-      CORS_ORIGINS: http://localhost:3000,http://finance-app:3000,http://${HOST_IP}:3000
+      CORS_ORIGINS: http://localhost:3000,http://finance-app:3000,http://${HOST_IP}:3000,https://finance.mskalski.dev
 
   finance-app:
     container_name: finance-app
@@ -54,5 +54,5 @@ services:
       - "3000:3000"
     environment:
       PUBLIC_API_URL: http://finance-backend:8000
-      PUBLIC_API_URL_BROWSER: http://${HOST_IP}:8000
-      ORIGIN: http://${HOST_IP}:3000
+      PUBLIC_API_URL_BROWSER: https://finance-api.mskalski.dev
+      ORIGIN: https://finance.mskalski.dev

--- a/ansible/docker-compose/traefik/services.yml
+++ b/ansible/docker-compose/traefik/services.yml
@@ -89,6 +89,22 @@ http:
       tls:
         certResolver: cloudflare
 
+    finance:
+      rule: "Host(`finance.mskalski.dev`)"
+      service: finance
+      entryPoints: [web, websecure]
+      middlewares: [internal-whitelist]
+      tls:
+        certResolver: cloudflare
+
+    finance-api:
+      rule: "Host(`finance-api.mskalski.dev`)"
+      service: finance-api
+      entryPoints: [web, websecure]
+      middlewares: [internal-whitelist]
+      tls:
+        certResolver: cloudflare
+
   services:
     jellyfin:
       loadBalancer:
@@ -144,6 +160,16 @@ http:
       loadBalancer:
         servers:
           - url: "http://192.168.20.219:8080"
+
+    finance:
+      loadBalancer:
+        servers:
+          - url: "http://192.168.20.106:3000"
+
+    finance-api:
+      loadBalancer:
+        servers:
+          - url: "http://192.168.20.106:8000"
 
   middlewares:
     internal-whitelist:

--- a/ansible/playbooks/deploy-adguard.yml
+++ b/ansible/playbooks/deploy-adguard.yml
@@ -43,6 +43,10 @@
         answer: "{{ traefik_lan_ip }}"
       - domain: synapse.mskalski.dev
         answer: "{{ traefik_lan_ip }}"
+      - domain: finance.mskalski.dev
+        answer: "{{ traefik_lan_ip }}"
+      - domain: finance-api.mskalski.dev
+        answer: "{{ traefik_lan_ip }}"
 
   handlers:
     - name: Restart systemd-resolved


### PR DESCRIPTION
## Motivation

Finance-buddy was only reachable via raw IP:port on custom-workloads,
unlike every other self-hosted app that lives behind `*.mskalski.dev`.

## Implementation information

- Added `finance` and `finance-api` routers in Traefik pointing at
  `192.168.20.106:3000` / `:8000`, gated by `internal-whitelist`
  (LAN + Tailscale + Cloudflare Tunnel) with Cloudflare cert resolver.
- AdGuard DNS rewrites for both hosts to the Traefik LAN IP so split
  DNS works internally.
- Compose env vars updated: `ORIGIN=https://finance.mskalski.dev`
  (SvelteKit CSRF), `PUBLIC_API_URL_BROWSER=https://finance-api.mskalski.dev`
  (avoids mixed content), and `CORS_ORIGINS` appended with the new
  HTTPS origin.

Alternatives considered: path-based routing on a single host
(rejected — frontend and backend run on distinct ports and the
upstream app already assumes split origins via `PUBLIC_API_URL_BROWSER`).

## Supporting documentation

None.

> Changelog: feat(traefik): add finance-buddy routes