### PR TITLE
fix(traefik): point finance to pet-projects LXC

### DIFF
--- a/ansible/docker-compose/traefik/services.yml
+++ b/ansible/docker-compose/traefik/services.yml
@@ -164,12 +164,12 @@ http:
     finance:
       loadBalancer:
         servers:
-          - url: "http://192.168.20.106:3000"
+          - url: "http://192.168.20.218:3000"
 
     finance-api:
       loadBalancer:
         servers:
-          - url: "http://192.168.20.106:8000"
+          - url: "http://192.168.20.218:8000"
 
   middlewares:
     internal-whitelist:


### PR DESCRIPTION
## Motivation

Accessing `finance.mskalski.dev` returned 404. The Traefik router
pointed at `192.168.20.106` (custom-workloads) but finance-buddy
actually runs on `pet-projects` LXC at `192.168.20.218`.

## Implementation information

Update `finance` and `finance-api` service URLs in Traefik file
provider to use `192.168.20.218` for both frontend (3000) and
backend (8000).

## Supporting documentation

None.

> Changelog: fix(traefik): point finance to pet-projects LXC