### PR TITLE
refactor(traefik): mount dynamic dir for reload

### DIFF
--- a/ansible/docker-compose/infrastructure-stack.yml
+++ b/ansible/docker-compose/infrastructure-stack.yml
@@ -12,7 +12,7 @@ services:
       - CF_DNS_API_TOKEN=${CF_DNS_API_TOKEN}
     volumes:
       - /opt/traefik/traefik.yml:/etc/traefik/traefik.yml:ro
-      - /opt/traefik/config/services.yml:/etc/traefik/services.yml:ro
+      - /opt/traefik/dynamic:/etc/traefik/dynamic:ro
       - /opt/traefik/acme.json:/etc/traefik/acme.json
       - /var/log/traefik:/var/log/traefik
     networks:

--- a/ansible/docker-compose/traefik/traefik.yml
+++ b/ansible/docker-compose/traefik/traefik.yml
@@ -20,7 +20,7 @@ entryPoints:
 
 providers:
   file:
-    filename: /etc/traefik/services.yml
+    directory: /etc/traefik/dynamic
     watch: true
 
 certificatesResolvers:

--- a/ansible/playbooks/deploy-infrastructure-stack.yml
+++ b/ansible/playbooks/deploy-infrastructure-stack.yml
@@ -22,7 +22,7 @@
       loop:
         - /opt/infrastructure
         - /opt/traefik
-        - /opt/traefik/config
+        - /opt/traefik/dynamic
         - /var/log/traefik
 
     - name: Ensure acme.json exists with restrictive permissions
@@ -43,8 +43,13 @@
     - name: Copy Traefik dynamic config
       ansible.builtin.copy:
         src: ../docker-compose/traefik/services.yml
-        dest: /opt/traefik/config/services.yml
+        dest: /opt/traefik/dynamic/services.yml
         mode: '0644'
+
+    - name: Remove legacy Traefik config path
+      ansible.builtin.file:
+        path: /opt/traefik/config
+        state: absent
 
     - name: Copy docker-compose file
       ansible.builtin.copy:


### PR DESCRIPTION
## Motivation

Every change to `services.yml` requires a manual `docker restart traefik`
because the host bind mount is file-level. Ansible's `copy` writes
atomically (temp file + rename), which swaps the host inode. The running
container still holds a handle to the original inode, so `watch: true`
never sees the update. This just bit us on the finance-buddy rollout.

## Implementation information

- `infrastructure-stack.yml`: bind `/opt/traefik/dynamic` as a directory
  instead of mounting `services.yml` by path.
- `traefik.yml`: switch file provider from `filename:` to `directory:`
  so any YAML in there is picked up.
- `deploy-infrastructure-stack.yml`: write config into
  `/opt/traefik/dynamic/services.yml`, create the directory, and remove
  the legacy `/opt/traefik/config` path.

Alternative considered: add a `notify: Restart Traefik` handler on the
copy task. Rejected — still restarts Traefik on every routing edit and
doesn't solve the underlying inotify gap.

## Supporting documentation

None.

> Changelog: refactor(traefik): mount dynamic dir for reload