### PR TITLE
refactor(synapse): non-root volumes + GH_TOKEN

### DIFF
--- a/ansible/docker-compose/synapse-stack.yml
+++ b/ansible/docker-compose/synapse-stack.yml
@@ -2,17 +2,20 @@
 services:
   synapse:
     container_name: synapse
-    image: ghcr.io/automaat/synapse:0.9.0
+    image: ghcr.io/automaat/synapse:0.11.0
     restart: unless-stopped
     ports:
       - "8080:8080"
     volumes:
-      - /data/synapse/home:/root/.synapse
-      - /data/synapse/claude:/root/.claude
-      - /data/synapse/codex:/root/.codex
+      - /data/synapse/home:/home/synapse/.synapse
+      - /data/synapse/claude:/home/synapse/.claude
+      - /data/synapse/codex:/home/synapse/.codex
     environment:
       SYNAPSE_PORT: "8080"
       SYNAPSE_STATIC_DIR: /app/web
+      GH_TOKEN: ${GH_TOKEN}
+    env_file:
+      - .env
     deploy:
       resources:
         limits:

--- a/ansible/playbooks/deploy-synapse.yml
+++ b/ansible/playbooks/deploy-synapse.yml
@@ -6,6 +6,9 @@
   vars:
     data_root: /data
     compose_file: /opt/synapse/docker-compose.yml
+    env_file: /opt/synapse/.env
+    synapse_uid: "1000"
+    synapse_gid: "1000"
 
   handlers:
     - name: Restart synapse
@@ -32,10 +35,22 @@
         path: "{{ item }}"
         state: directory
         mode: '0755'
-        owner: "0"
-        group: "0"
+        owner: "{{ synapse_uid }}"
+        group: "{{ synapse_gid }}"
       loop:
         - "{{ data_root }}/synapse"
+        - "{{ data_root }}/synapse/home"
+        - "{{ data_root }}/synapse/claude"
+        - "{{ data_root }}/synapse/codex"
+
+    - name: Chown synapse data tree to non-root uid (migration from root-owned layout)
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        recurse: true
+        owner: "{{ synapse_uid }}"
+        group: "{{ synapse_gid }}"
+      loop:
         - "{{ data_root }}/synapse/home"
         - "{{ data_root }}/synapse/claude"
         - "{{ data_root }}/synapse/codex"
@@ -52,29 +67,53 @@
         dest: "{{ compose_file }}"
         mode: '0644'
 
+    - name: Extract GitHub token from sops
+      ansible.builtin.command: >
+        sops -d --extract '["github_token"]'
+        {{ playbook_dir }}/../secrets/secrets.yaml
+      register: gh_token_result
+      delegate_to: localhost
+      become: false
+      no_log: true
+      changed_when: false
+
+    - name: Set GitHub token fact
+      ansible.builtin.set_fact:
+        gh_token: "{{ gh_token_result.stdout }}"
+      no_log: true
+
+    - name: Create .env file with GitHub token
+      ansible.builtin.copy:
+        content: |
+          GH_TOKEN={{ gh_token }}
+        dest: "{{ env_file }}"
+        mode: '0600'
+      no_log: true
+      notify: Restart synapse
+
     - name: Install klaudiush hooks for Claude Code
       ansible.builtin.copy:
         src: synapse/claude/settings.json
         dest: "{{ data_root }}/synapse/claude/settings.json"
         mode: '0644'
-        owner: "0"
-        group: "0"
+        owner: "{{ synapse_uid }}"
+        group: "{{ synapse_gid }}"
 
     - name: Install global CLAUDE.md
       ansible.builtin.copy:
         src: synapse/claude/CLAUDE.md
         dest: "{{ data_root }}/synapse/claude/CLAUDE.md"
         mode: '0644'
-        owner: "0"
-        group: "0"
+        owner: "{{ synapse_uid }}"
+        group: "{{ synapse_gid }}"
 
     - name: Install Codex config with hooks feature flag
       ansible.builtin.copy:
         src: synapse/codex/config.toml
         dest: "{{ data_root }}/synapse/codex/config.toml"
         mode: '0644'
-        owner: "0"
-        group: "0"
+        owner: "{{ synapse_uid }}"
+        group: "{{ synapse_gid }}"
         force: false
 
     - name: Install klaudiush hooks for Codex
@@ -82,16 +121,16 @@
         src: synapse/codex/hooks.json
         dest: "{{ data_root }}/synapse/codex/hooks.json"
         mode: '0644'
-        owner: "0"
-        group: "0"
+        owner: "{{ synapse_uid }}"
+        group: "{{ synapse_gid }}"
 
     - name: Install global AGENTS.md
       ansible.builtin.copy:
         src: synapse/codex/AGENTS.md
         dest: "{{ data_root }}/synapse/codex/AGENTS.md"
         mode: '0644'
-        owner: "0"
-        group: "0"
+        owner: "{{ synapse_uid }}"
+        group: "{{ synapse_gid }}"
 
     - name: Enable Prometheus metrics in synapse config
       ansible.builtin.blockinfile:

--- a/ansible/secrets/secrets.yaml
+++ b/ansible/secrets/secrets.yaml
@@ -21,6 +21,7 @@ adguard_admin_user: ENC[AES256_GCM,data:u4YSdYN46OE=,iv:pUX1VaI+XiYjsNUGvGCQAbQi
 adguard_admin_password: ENC[AES256_GCM,data:tk7f+RfmiaT68PeJ80Wj6yWeV95Rba8+2g==,iv:l0EnIas4vIe6tB5oMvOuLrkXweM8hnKjBJzj8IGwINc=,tag:u4W80ZZNGyHh+OeZJo7hMQ==,type:str]
 cloudflare_dns_api_token: ENC[AES256_GCM,data:pfmBo/dWCfWw+yLXix1W9cjRYGvvLc8JK/0xP9sOzG3PiOpF5X3Y+wCSo4BK+jYynGO6zQg=,iv:ZDIQsLyOA4PnKhuF9yb2HY62frrYOrjiqZ2kRy/8CEg=,tag:eC+sb2lDjuFtSubUvXsUcQ==,type:str]
 adguard_admin_password_hash: ENC[AES256_GCM,data:EFcBc9Fa/Ov435c8OQDNqDAJltUj8oQLyplR8mlDiSfeBJbXs4iIG8wBTxRfBEXtjB0VB8EIfeoJlSUY,iv:7DpImqgUXZpKzWDhVh2Pq3qxku8GpBeXQhUaPPdFbuQ=,tag:OZhPTxDeVO0K7kJW/39g/g==,type:str]
+github_token: ENC[AES256_GCM,data:fjkHrMDOCKTpjWjqCU2fS3u1KZvo1ffIk2DwnoM/5nOwaojvmgm/jw==,iv:79wHKpNuHYVO/G+oYsm76hv9kSzQGnJ1wKPluZwOXrU=,tag:AVXux/ts0MbYpZQhIZJCBA==,type:str]
 sops:
     age:
         - recipient: age1kfklkd3xuacvfu0gy35v7cwk5lw8y9xv0lr5hs2ddyn82ww9mdlslfth6h
@@ -41,7 +42,7 @@ sops:
             Q0dwbTZJaUpRbVVzWmlGRGxZdXJpMzQKWCWSoy6+0qiWqkrJXgHLpCN2WTE3oSEk
             mYfd6+zHm7e+8VOMDHejDgoqkPSwIOCy24ZcflfNQULiOpPXiS1/lQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-13T10:46:36Z"
-    mac: ENC[AES256_GCM,data:ZIXTmBkYDvR8b6eL8SQr1NjMLuuUWK8SF2+8ZcY7xY65aF2YuSduNskvtsavrSTfWf5Nh33eNm4dkoYIG7FhGcXBbQfLZbVo8Gu9bIpmtgjnlr8IVPA2/Pw3Dgh3Y5gXEO8oyJ6v4i2Qy6hrLk14kBo80SjsJqpx6ncirG8JuDI=,iv:emSoR1CJn2HETF9901aap90Lt3Irc4ejZne+TlVzWZY=,tag:PMsX/ixR1F7rQ2eEK8rUZA==,type:str]
+    lastmodified: "2026-04-14T07:45:01Z"
+    mac: ENC[AES256_GCM,data:jYBehev0jg8/JMx7IiEPl8X0gz19oWUXUfnrpypYfwejjg2Ubt8+t4n4DY3vRnfWW4XN+EJeZzmFyZCESG2Z60Sr5IJqIGU6Wb2p/JYknNWjQCL7CQL5KMnygNxrRxyJORueSGYDiU7DIIF1zai4N7rbODuqOY88HziaphVLNL8=,iv:HfMxBNrII07+XoQCjV2wyba8HHdI5vTBlXaje+CT+bE=,tag:A6+50GsJ0KrX9pAYZLGnuA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0


### PR DESCRIPTION
## Motivation

Two issues observed on home-nas synapse:

1. **Orchestrator auto-start failing every 60s.** Claude CLI refuses `--dangerously-skip-permissions` under uid 0; every spawned child exits 1 with the root/sudo security error. Active tasks stall.
2. **pr-monitor / renovate / issues fetchers WARN-looping** every 5 minutes on `gh auth login … or populate the GH_TOKEN environment variable`. No GH_TOKEN is exposed to the container.

## Implementation information

- **Container now runs as uid 1000 (synapse user).** Bind-mount paths move from `/root/.*` → `/home/synapse/.*` to match the new HOME. Gated on `Automaat/synapse` publishing `v0.11.0` with the non-root Dockerfile change (Automaat/synapse#416).
- **Data tree chowned on every deploy** (`/data/synapse/{home,claude,codex}` → 1000:1000) to migrate from the existing root-owned layout. Existing session state and tokens preserved.
- **All `copy` task owners bumped from `"0"` → `"{{ synapse_uid }}"`.**
- **`GH_TOKEN` via sops + .env:** new `github_token` key in `ansible/secrets/secrets.yaml`, extracted on deploy into `/opt/synapse/.env` (mode 0600) and consumed by `env_file: .env` in the compose service. Restart handler notified on .env change.
- Image tag bumped to `0.11.0`.

**Alternatives considered:**
- `IS_SANDBOX=1` env var instead of non-root user — works but relies on a semi-documented escape hatch; the upstream fix is cleaner.
- Hardcoding the token in a committed file — rejected; sops is already wired for cloudflare secrets, same pattern applies.

## Supporting documentation

- Related: Automaat/synapse#416 (Dockerfile non-root) — must merge and publish `v0.11.0` before this PR is deployed.

> Changelog: skip