### PR TITLE
chore(deps): bump synapse image to v0.12.0

### DIFF
--- a/ansible/docker-compose/synapse-stack.yml
+++ b/ansible/docker-compose/synapse-stack.yml
@@ -2,7 +2,7 @@
 services:
   synapse:
     container_name: synapse
-    image: ghcr.io/automaat/synapse:0.11.0
+    image: ghcr.io/automaat/synapse:0.12.0
     restart: unless-stopped
     ports:
       - "8080:8080"


### PR DESCRIPTION
## Motivation

Picks up [Automaat/synapse#418](https://github.com/Automaat/synapse/pull/418) (`fix(issues): only sync from registered projects`) — stops the GitHub issues fetcher from auto-importing tasks from repos that aren't registered as synapse projects. Without this bump the kumahq/kuma issues the user has assigned will keep recreating task cards every 5 minutes.

## Implementation information

Image tag bump only — no config or volume changes. Next `ansible-playbook deploy-synapse.yml` pulls `0.12.0` and restarts the container.

## Supporting documentation

- Automaat/synapse#418

> Changelog: skip