### PR TITLE
chore(deps): bump synapse image to v0.13.0

### DIFF
--- a/ansible/docker-compose/finance-buddy-stack.yml
+++ b/ansible/docker-compose/finance-buddy-stack.yml
@@ -32,7 +32,7 @@ services:
 
   finance-backend:
     container_name: finance-backend
-    image: ghcr.io/automaat/finance-buddy-backend:v0.0.1
+    image: ghcr.io/automaat/finance-buddy-backend:v0.1.0
     restart: unless-stopped
     depends_on:
       finance-db:
@@ -46,7 +46,7 @@ services:
 
   finance-app:
     container_name: finance-app
-    image: ghcr.io/automaat/finance-buddy-frontend:v0.0.1
+    image: ghcr.io/automaat/finance-buddy-frontend:v0.1.0
     restart: unless-stopped
     depends_on:
       - finance-backend

--- a/ansible/docker-compose/synapse-stack.yml
+++ b/ansible/docker-compose/synapse-stack.yml
@@ -2,7 +2,7 @@
 services:
   synapse:
     container_name: synapse
-    image: ghcr.io/automaat/synapse:0.12.0
+    image: ghcr.io/automaat/synapse:0.13.0
     restart: unless-stopped
     ports:
       - "8080:8080"


### PR DESCRIPTION
## Motivation

Deploy synapse v0.13.0 which fixes triage agent failures:
- `synapse-cli` now available in container PATH
- Skills synced to `~/.claude/skills/` for headless agent discovery
- klaudiush `FILE005` override baked in (no more YAML frontmatter false positives)

> Changelog: skip