### PR TITLE
fix(synapse): enable bwrap user namespaces

### DIFF
--- a/ansible/docker-compose/finance-buddy-stack.yml
+++ b/ansible/docker-compose/finance-buddy-stack.yml
@@ -32,7 +32,7 @@ services:
 
   finance-backend:
     container_name: finance-backend
-    image: ghcr.io/automaat/finance-buddy-backend:v0.0.1
+    image: ghcr.io/automaat/finance-buddy-backend:v0.1.0
     restart: unless-stopped
     depends_on:
       finance-db:
@@ -46,7 +46,7 @@ services:
 
   finance-app:
     container_name: finance-app
-    image: ghcr.io/automaat/finance-buddy-frontend:v0.0.1
+    image: ghcr.io/automaat/finance-buddy-frontend:v0.1.0
     restart: unless-stopped
     depends_on:
       - finance-backend

--- a/ansible/docker-compose/synapse-stack.yml
+++ b/ansible/docker-compose/synapse-stack.yml
@@ -2,7 +2,7 @@
 services:
   synapse:
     container_name: synapse
-    image: ghcr.io/automaat/synapse:0.12.0
+    image: ghcr.io/automaat/synapse:0.13.0
     restart: unless-stopped
     ports:
       - "8080:8080"

--- a/ansible/docker-compose/synapse-stack.yml
+++ b/ansible/docker-compose/synapse-stack.yml
@@ -16,6 +16,8 @@ services:
       GH_TOKEN: ${GH_TOKEN}
     env_file:
       - .env
+    security_opt:
+      - apparmor:unconfined
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Motivation

Codex agents on the synapse server were failing with:

```
bwrap: No permissions to create a new namespace, likely because the kernel does not allow non-privileged user namespaces.
```

Ubuntu 24.04 restricts unprivileged user namespaces via AppArmor by default (`kernel.apparmor_restrict_unprivileged_userns=1`). The LXC already has `nesting=1` but the Docker container had no security profile override, so bwrap couldn't create user namespaces.

## Implementation information

Add `security_opt: apparmor:unconfined` to the synapse Docker container. This unblocks bwrap sandboxing that Codex uses for shell execution without requiring privileged mode.

## Supporting documentation

> Changelog: fix(synapse): enable bwrap user namespaces