### PR TITLE
chore(media): remove ollama from jellyfin stack

### DIFF
--- a/ansible/docker-compose/jellyfin-stack.yml
+++ b/ansible/docker-compose/jellyfin-stack.yml
@@ -33,20 +33,6 @@ services:
       - 5055:5055
     restart: unless-stopped
 
-  ollama:
-    image: ollama/ollama:0.20.6-rocm
-    container_name: ollama
-    devices:
-      - /dev/dri:/dev/dri  # AMD GPU for inference
-    environment:
-      - OLLAMA_HOST=0.0.0.0:11434
-      - HSA_OVERRIDE_GFX_VERSION=11.0.0  # AMD 780M compatibility
-    volumes:
-      - /data/ollama/models:/root/.ollama
-    ports:
-      - 11434:11434
-    restart: unless-stopped
-
   navidrome:
     image: deluan/navidrome:0.61.2
     container_name: navidrome

--- a/ansible/playbooks/deploy-media-stack.yml
+++ b/ansible/playbooks/deploy-media-stack.yml
@@ -34,7 +34,6 @@
         - "{{ data_root }}"
         - "{{ data_root }}/jellyfin/config"
         - "{{ data_root }}/jellyseerr/config"
-        - "{{ data_root }}/ollama/models"
         - "{{ data_root }}/navidrome/config"
         - "{{ data_root }}/media"
         - "{{ data_root }}/media/tv"
@@ -68,5 +67,4 @@
       loop:
         - jellyfin
         - jellyseerr
-        - ollama
         - navidrome


### PR DESCRIPTION
## Motivation

Ollama is not used on the NAS.

## Implementation information

Removed ollama service from docker-compose and dropped the data dir creation + container verify steps from the playbook.

## Supporting documentation

> Changelog: skip