### PR TITLE
chore(synapse): bump to v0.16.0

### DIFF
--- a/ansible/docker-compose/synapse-stack.yml
+++ b/ansible/docker-compose/synapse-stack.yml
@@ -2,7 +2,7 @@
 services:
   synapse:
     container_name: synapse
-    image: ghcr.io/automaat/synapse:0.15.0
+    image: ghcr.io/automaat/synapse:0.16.0
     restart: unless-stopped
     ports:
       - "8080:8080"


### PR DESCRIPTION
## Motivation

Bump Synapse to latest release v0.16.0.

## Implementation information

Version bump in docker-compose stack file.

## Supporting documentation

> Changelog: chore(synapse): bump to v0.16.0