### PR TITLE
chore(synapse): bump to v0.19.0

### DIFF
--- a/ansible/docker-compose/synapse-stack.yml
+++ b/ansible/docker-compose/synapse-stack.yml
@@ -2,7 +2,7 @@
 services:
   synapse:
     container_name: synapse
-    image: ghcr.io/automaat/synapse:0.18.0
+    image: ghcr.io/automaat/synapse:0.19.0
     restart: unless-stopped
     ports:
       - "8080:8080"


### PR DESCRIPTION
## Motivation

Bump Synapse to latest release v0.19.0.

## Implementation information

Updated image tag in `ansible/docker-compose/synapse-stack.yml` from `0.18.0` to `0.19.0`.

> Changelog: skip