### PR TITLE
chore(synapse): bump to v0.20.0

### DIFF
--- a/ansible/docker-compose/synapse-stack.yml
+++ b/ansible/docker-compose/synapse-stack.yml
@@ -2,7 +2,7 @@
 services:
   synapse:
     container_name: synapse
-    image: ghcr.io/automaat/synapse:0.19.0
+    image: ghcr.io/automaat/synapse:0.20.0
     restart: unless-stopped
     ports:
       - "8080:8080"


### PR DESCRIPTION
## Motivation

Routine version bump to keep Synapse up to date.

## Implementation information

Updated image tag from `0.19.0` to `0.20.0` in `ansible/docker-compose/synapse-stack.yml`.

> Changelog: skip