### PR TITLE
chore(synapse): bump to v0.22.0

### DIFF
--- a/ansible/docker-compose/synapse-stack.yml
+++ b/ansible/docker-compose/synapse-stack.yml
@@ -2,7 +2,7 @@
 services:
   synapse:
     container_name: synapse
-    image: ghcr.io/automaat/synapse:0.21.0
+    image: ghcr.io/automaat/synapse:0.22.0
     restart: unless-stopped
     ports:
       - "8080:8080"


### PR DESCRIPTION
## Motivation

Routine version bump to keep synapse up to date.

## Implementation information

Updated `ghcr.io/automaat/synapse` from `0.21.0` to `0.22.0` in `ansible/docker-compose/synapse-stack.yml`.

## Supporting documentation

> Changelog: chore(synapse): bump to v0.22.0