### PR TITLE
chore(sybra): bump to v0.26.0

### DIFF
--- a/ansible/docker-compose/sybra-stack.yml
+++ b/ansible/docker-compose/sybra-stack.yml
@@ -2,7 +2,7 @@
 services:
   sybra:
     container_name: sybra
-    image: ghcr.io/automaat/sybra:0.25.0
+    image: ghcr.io/automaat/sybra:0.26.0
     restart: unless-stopped
     ports:
       - "8080:8080"


### PR DESCRIPTION
## Motivation

Bump sybra image to v0.26.0.

## Implementation information

Update `ansible/docker-compose/sybra-stack.yml` image tag from 0.25.0 to 0.26.0.

## Supporting documentation

Follows pattern of #152 (v0.25.0 bump).

> Changelog: skip