### PR TITLE
feat(adguard): expose DoH endpoint via Traefik

### DIFF
--- a/ansible/docker-compose/adguard-stack.yml
+++ b/ansible/docker-compose/adguard-stack.yml
@@ -8,6 +8,7 @@ services:
       - "53:53/tcp"
       - "53:53/udp"
       - "3000:3000/tcp"  # Web UI
+      - "3443:3443/tcp"  # Plain-HTTP DoH endpoint (behind Traefik)
     volumes:
       - /opt/adguard/work:/opt/adguardhome/work
       - /opt/adguard/conf:/opt/adguardhome/conf

--- a/ansible/docker-compose/traefik/services.yml
+++ b/ansible/docker-compose/traefik/services.yml
@@ -105,6 +105,13 @@ http:
       tls:
         certResolver: cloudflare
 
+    adguard-doh:
+      rule: "Host(`dns.mskalski.dev`) && Path(`/dns-query`)"
+      service: adguard-doh
+      entryPoints: [websecure]
+      tls:
+        certResolver: cloudflare
+
   services:
     jellyfin:
       loadBalancer:
@@ -170,6 +177,16 @@ http:
       loadBalancer:
         servers:
           - url: "http://192.168.20.218:8000"
+
+    adguard-doh:
+      loadBalancer:
+        serversTransport: adguard-insecure
+        servers:
+          - url: "https://192.168.10.222:3443"
+
+  serversTransports:
+    adguard-insecure:
+      insecureSkipVerify: true
 
   middlewares:
     internal-whitelist:

--- a/ansible/playbooks/deploy-adguard.yml
+++ b/ansible/playbooks/deploy-adguard.yml
@@ -47,6 +47,8 @@
         answer: "{{ traefik_lan_ip }}"
       - domain: finance-api.mskalski.dev
         answer: "{{ traefik_lan_ip }}"
+      - domain: dns.mskalski.dev
+        answer: "{{ traefik_lan_ip }}"
 
   handlers:
     - name: Restart systemd-resolved
@@ -76,6 +78,34 @@
         - /opt/adguard
         - "{{ adguard_config_dir }}"
         - "{{ adguard_work_dir }}"
+
+    - name: Check for existing DoH self-signed cert
+      ansible.builtin.stat:
+        path: "{{ adguard_config_dir }}/doh-cert.pem"
+      register: doh_cert_stat
+
+    - name: Generate self-signed DoH cert (Traefik validates with insecureSkipVerify)
+      ansible.builtin.command: >
+        openssl req -x509 -newkey rsa:2048 -nodes
+        -keyout {{ adguard_config_dir }}/doh-key.pem
+        -out {{ adguard_config_dir }}/doh-cert.pem
+        -days 3650
+        -subj "/CN=dns.mskalski.dev"
+        -addext "subjectAltName=DNS:dns.mskalski.dev"
+      when: not doh_cert_stat.stat.exists
+      changed_when: true
+      notify: Restart AdGuard Home
+
+    - name: Fix DoH cert permissions
+      ansible.builtin.file:
+        path: "{{ item }}"
+        mode: '0644'
+        owner: root
+        group: root
+      loop:
+        - "{{ adguard_config_dir }}/doh-cert.pem"
+        - "{{ adguard_config_dir }}/doh-key.pem"
+      when: not doh_cert_stat.stat.exists
 
     - name: Ensure systemd-resolved drop-in directory exists
       ansible.builtin.file:

--- a/ansible/playbooks/templates/AdGuardHome.yaml.j2
+++ b/ansible/playbooks/templates/AdGuardHome.yaml.j2
@@ -48,6 +48,8 @@ dns:
   trusted_proxies:
     - 127.0.0.0/8
     - ::1/128
+    - 172.16.0.0/12
+    - 192.168.10.0/24
   cache_size: 4194304
   cache_ttl_min: 0
   cache_ttl_max: 0
@@ -77,19 +79,19 @@ dns:
   serve_plain_dns: true
   hostsfile_enabled: true
 tls:
-  enabled: false
-  server_name: ""
+  enabled: true
+  server_name: "dns.mskalski.dev"
   force_https: false
-  port_https: 443
+  port_https: 3443
   port_dns_over_tls: 853
   port_dns_over_quic: 853
   port_dnscrypt: 0
   dnscrypt_config_file: ""
-  allow_unencrypted_doh: false
+  allow_unencrypted_doh: true
   certificate_chain: ""
   private_key: ""
-  certificate_path: ""
-  private_key_path: ""
+  certificate_path: /opt/adguardhome/conf/doh-cert.pem
+  private_key_path: /opt/adguardhome/conf/doh-key.pem
   strict_sni_check: false
 querylog:
   dir_path: ""


### PR DESCRIPTION
## Motivation

Browsers using DNS-over-HTTPS (Edge, Firefox, Chrome with secure DNS enabled) bypass AdGuard's split-horizon DNS rewrites. This caused LAN-only services like `jellyfin.mskalski.dev` to resolve through Cloudflare and return 404 (no tunnel ingress rule), even from inside the home network.

## Implementation information

Adds `dns.mskalski.dev` DoH endpoint served by AdGuard, proxied through Traefik:

- AdGuard serves DoH on port 3443 with a self-signed cert (generated at first deploy via openssl)
- Traefik router for `dns.mskalski.dev` terminates TLS with the existing Cloudflare wildcard cert and forwards to AdGuard using `insecureSkipVerify: true` (cert validation between Traefik and AdGuard on localhost network is not meaningful)
- AdGuard rewrite `dns.mskalski.dev -> 192.168.10.222` so on-LAN clients resolve the DoH hostname even when their only DNS is DoH
- `trusted_proxies` expanded to cover Docker bridges and LAN
- `allow_unencrypted_doh: true` retained for flexibility but TLS path is the active one

Required public DNS record (added manually): `dns.mskalski.dev A 192.168.10.222` (DNS-only/grey cloud).

### Alternatives considered
- Expose Jellyfin via Cloudflare Tunnel — rejected, service is intentionally LAN-only
- Users disable browser DoH — fragile, browser-by-browser, and Edge/Chrome auto-enable it

## Supporting documentation

Validated end-to-end: DoH query through `https://dns.mskalski.dev/dns-query` returns `192.168.10.222` for `jellyfin.mskalski.dev`. Edge + Chrome confirmed working after configuring custom secure DNS provider.

> Changelog: feat(adguard): expose DoH endpoint via Traefik