### PR TITLE
chore(sybra): bump to v0.28.0

### DIFF
--- a/ansible/docker-compose/sybra-stack.yml
+++ b/ansible/docker-compose/sybra-stack.yml
@@ -2,7 +2,7 @@
 services:
   sybra:
     container_name: sybra
-    image: ghcr.io/automaat/sybra:0.26.0
+    image: ghcr.io/automaat/sybra:0.28.0
     restart: unless-stopped
     ports:
       - "8080:8080"


### PR DESCRIPTION
## Motivation

Bump sybra to latest release v0.28.0.

## Implementation information

Updated container image tag in `ansible/docker-compose/sybra-stack.yml` from `0.25.0` to `0.28.0`.

> Changelog: skip