### PR TITLE
fix(sybra): disable codex bwrap + tune limits

### DIFF
--- a/ansible/docker-compose/sybra-stack.yml
+++ b/ansible/docker-compose/sybra-stack.yml
@@ -14,6 +14,13 @@ services:
       SYBRA_PORT: "8080"
       SYBRA_STATIC_DIR: /app/web
       GH_TOKEN: ${GH_TOKEN}
+      # LXC kernels ship with kernel.unprivileged_userns_clone=0, which makes
+      # bwrap — the process isolator codex uses for --full-auto — crash
+      # before the agent can execute its first tool. The container is
+      # already the sandbox, so swap --full-auto for
+      # --sandbox danger-full-access. This flag is honored by
+      # codexSandboxArgs in internal/agent/manager.go.
+      SYBRA_DISABLE_CODEX_SANDBOX: "1"
     env_file:
       - .env
     security_opt:

--- a/ansible/playbooks/deploy-sybra.yml
+++ b/ansible/playbooks/deploy-sybra.yml
@@ -148,6 +148,25 @@
         create: false
       notify: Restart sybra
 
+    # The server container has 14GB RAM and 6 cores (see ansible/playbooks/
+    # setup-sybra-lxc.yml). The default max_concurrent=3 was sized for a
+    # laptop and caused "max concurrent agents reached (3)" errors during
+    # batch workflow runs on 2026-04-16. max_turns=100 brings the guardrail
+    # down from the default 150 after agent 70affeff burned 150 turns on a
+    # test task. log_retention_days=7 matches the rotation cadence of the
+    # rotating slog writer.
+    - name: Tune agent defaults in sybra config
+      ansible.builtin.blockinfile:
+        path: "{{ data_root }}/sybra/home/config.yaml"
+        marker: "# {mark} ANSIBLE MANAGED BLOCK - agent"
+        block: |
+          agent:
+              max_concurrent: 10
+              max_turns: 100
+              log_retention_days: 7
+        create: false
+      notify: Restart sybra
+
     - name: Deploy sybra stack
       community.docker.docker_compose_v2:
         project_src: /opt/sybra


### PR DESCRIPTION
## Motivation

Companion to the app-side PR https://github.com/Automaat/sybra/pull/537 closing out the
2026-04-16 server log review findings. Two infra changes the app
cannot make for itself.

1. **Codex `bwrap` crashes in LXC.** `codex --full-auto` wraps each
   tool invocation in `bwrap`, which needs unprivileged user
   namespaces. The synapse LXC runs with
   `kernel.unprivileged_userns_clone=0`, so every codex run dies with
   `bwrap: No permissions to create a new namespace` before executing
   its first tool. Sybra already supports a `SYBRA_DISABLE_CODEX_SANDBOX=1`
   env gate that swaps `--full-auto` for `--sandbox danger-full-access`;
   the container itself is the sandbox boundary.

2. **Default agent limits too tight for the server.** The
   `max_concurrent: 3` default was sized for a laptop and hit
   repeatedly during the 2026-04-16 batch runs. `max_turns: 150`
   was burned in full by a single task. Per-agent NDJSON logs have
   no retention, so 463 files accumulated in
   `/data/sybra/home/logs/agents/`.

## Implementation information

**Compose (`ansible/docker-compose/sybra-stack.yml`)**: add
`SYBRA_DISABLE_CODEX_SANDBOX: "1"` to the `sybra` service env. The
gate is honored by `codexSandboxArgs` in
`internal/agent/manager.go` and was introduced in the upstream
commit that went in with the `sybra` #533 merge.

**Playbook (`ansible/playbooks/deploy-sybra.yml`)**: new
`ANSIBLE MANAGED BLOCK - agent` in `config.yaml` setting:

```yaml
agent:
    max_concurrent: 10
    max_turns: 100
    log_retention_days: 7
```

`log_retention_days` is the new field shipping in the app PR; it
drives the per-agent NDJSON prune loop (startup + daily).

Values picked for the LXC: 14G RAM / 6 cores comfortably supports
10 concurrent agents (~1.4G each budgeted). `max_turns: 100` is
tight enough to escalate before a runaway agent chews through a
full context, loose enough for multi-step refactors. 7-day
retention matches the rotating slog writer's cadence.

## Supporting documentation

- Session log of the 2026-04-16 server audit with the failure
  patterns mapped to each fix.
- Upstream app changes: https://github.com/Automaat/sybra/pull/537