### PR TITLE
fix(sybra): strip legacy agent block, bump turns

### DIFF
--- a/ansible/playbooks/deploy-sybra.yml
+++ b/ansible/playbooks/deploy-sybra.yml
@@ -148,13 +148,28 @@
         create: false
       notify: Restart sybra
 
-    # The server container has 14GB RAM and 6 cores (see ansible/playbooks/
+    # A raw top-level `agent:` block in config.yaml predates this managed
+    # block (hand-edited override for require_permissions). Leaving it
+    # produces duplicate mapping keys when blockinfile appends the managed
+    # version, which breaks YAML unmarshal at container start. Strip the
+    # raw block via `before:` anchor so the managed block itself is never
+    # touched. Idempotent: after migration the regex no longer matches.
+    - name: Remove legacy unmanaged agent block (one-time migration)
+      ansible.builtin.replace:
+        path: "{{ data_root }}/sybra/home/config.yaml"
+        before: '# BEGIN ANSIBLE MANAGED BLOCK - agent'
+        regexp: '(?m)^agent:\n(?:    [^\n]+\n)+'
+        replace: ''
+
+    # The synapse LXC has 14GB RAM and 6 cores (see ansible/playbooks/
     # setup-sybra-lxc.yml). The default max_concurrent=3 was sized for a
     # laptop and caused "max concurrent agents reached (3)" errors during
-    # batch workflow runs on 2026-04-16. max_turns=100 brings the guardrail
-    # down from the default 150 after agent 70affeff burned 150 turns on a
-    # test task. log_retention_days=7 matches the rotation cadence of the
-    # rotating slog writer.
+    # batch workflow runs on 2026-04-16. max_turns=200 gives batch refactors
+    # headroom above the 150 default without letting a runaway agent chew
+    # through an unbounded context. log_retention_days=7 matches the
+    # rotating slog writer cadence. require_permissions=false preserves
+    # the prior manual override; the container is already the sandbox
+    # boundary so agents run with --dangerously-skip-permissions.
     - name: Tune agent defaults in sybra config
       ansible.builtin.blockinfile:
         path: "{{ data_root }}/sybra/home/config.yaml"
@@ -162,8 +177,9 @@
         block: |
           agent:
               max_concurrent: 10
-              max_turns: 100
+              max_turns: 200
               log_retention_days: 7
+              require_permissions: false
         create: false
       notify: Restart sybra
 


### PR DESCRIPTION
## Motivation

Two regressions from the prior home-nas PR (#159) that merged the
initial agent-tuning block:

1. **Duplicate YAML mapping key.** The server's `config.yaml`
   already carried a hand-written top-level `agent:` block (a
   `require_permissions: false` override). The `blockinfile` task
   appended a *second* `agent:` block with ANSIBLE MANAGED markers,
   producing:

   ```
   fatal: config: yaml: unmarshal errors:
     line 25: mapping key "agent" already defined at line 4
   ```

   and the container hit a restart loop. The deploy workflow's
   final `Verify container is running` task then failed the job.

2. **`max_turns: 100` too tight.** Initial tuning halved the 150
   default after one test agent burned all 150. In practice 100 is
   not enough headroom for batch refactors across multi-package
   Go/frontend changes — 200 keeps guardrails meaningful without
   letting a runaway agent chew through unbounded context.

## Implementation information

**Migration task**: new `ansible.builtin.replace` step strips any
raw top-level `agent:` block outside the ANSIBLE MANAGED markers.
The `before:` anchor keeps the managed block itself untouched, and
the regex matches `^agent:` followed by indented child lines —
idempotent after the first run.

**Managed block** now owns `require_permissions: false` as well, so
the migration does not lose that setting.

**`max_turns`**: `100 -> 200`.

Server has already been fixed by hand (legacy block removed,
`require_permissions` folded into managed block, `max_turns: 200`
applied) so next deploy run finds the file in its final shape and
the playbook is a no-op.

## Supporting documentation

- Failing run: https://github.com/Automaat/home-nas/actions/runs/24531630183/job/71716212792
- Prior PR that introduced the collision: https://github.com/Automaat/home-nas/pull/159