### PR TITLE
chore(sybra): bump to v0.30.0

### DIFF
--- a/ansible/docker-compose/sybra-stack.yml
+++ b/ansible/docker-compose/sybra-stack.yml
@@ -2,7 +2,7 @@
 services:
   sybra:
     container_name: sybra
-    image: ghcr.io/automaat/sybra:0.29.0
+    image: ghcr.io/automaat/sybra:0.30.0
     restart: unless-stopped
     ports:
       - "8080:8080"


### PR DESCRIPTION
## Motivation

Bump sybra from 0.29.0 to 0.30.0.

## Implementation information

Updated image tag in `ansible/docker-compose/sybra-stack.yml`.

> Changelog: chore(sybra): bump to v0.30.0